### PR TITLE
Update acquisition scheme and model handling for clinical data (deltas unknown)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
 - python setup.py install --record installed_files.txt
 
 script:
-- flake8 --ignore N802,N806,E731,F401 `find . -name \*.py | grep -v setup.py | grep -v /doc/`
+- flake8 --ignore N802,N806,E731,F401,W504 `find . -name \*.py | grep -v setup.py | grep -v /doc/`
 - nosetests --with-coverage -v
   #- travis-sphinx build -s doc
   #- for a in examples/*ipynb; do 

--- a/dmipy/core/acquisition_scheme.py
+++ b/dmipy/core/acquisition_scheme.py
@@ -117,7 +117,7 @@ class DmipyAcquisitionScheme:
             if self.qvalues is not None:
                 self.shell_qvalues = self.qvalues[first_indices]
             self.shell_gradient_strengths = None
-            if self.shell_gradient_strengths is not None:
+            if self.gradient_strengths is not None:
                 self.shell_gradient_strengths = (
                     self.gradient_strengths[first_indices])
             self.shell_delta = None
@@ -895,18 +895,22 @@ def gtab_dmipy2dipy(dmipy_gradient_table):
     delta = dmipy_gradient_table.delta
     Delta = dmipy_gradient_table.Delta
 
-    if len(np.unique(delta)) == 1:
-        delta = delta[0]
-    elif len(np.unique(delta)) > 1:
+    if len(np.unique(delta)) > 1:
         msg = "Cannot create Dipy GradientTable for Acquisition schemes with "
         msg += "multiple delta (pulse duration) values, due to current "
         msg += "limitations of Dipy GradientTables."
-    if len(np.unique(Delta)) == 1:
-        Delta = Delta[0]
-    elif len(np.unique(Delta)) > 1:
+        raise ValueError(msg)
+    elif len(np.unique(delta)) == 1:
+        delta = delta[0]
+
+    if len(np.unique(Delta)) > 1:
         msg = "Cannot create Dipy GradientTable for Acquisition schemes with "
         msg += "multiple Delta (pulse sepration) values, due to current "
         msg += "limitations of Dipy GradientTables."
+        raise ValueError(msg)
+    elif len(np.unique(Delta)) == 1:
+        Delta = Delta[0]
+
     dipy_gradient_table = gradient_table(
         bvals=bvals, bvecs=bvecs, small_delta=delta, big_delta=Delta)
     return dipy_gradient_table

--- a/dmipy/core/acquisition_scheme.py
+++ b/dmipy/core/acquisition_scheme.py
@@ -468,7 +468,7 @@ class SphericalMeanAcquisitionScheme:
 
 
 def acquisition_scheme_from_bvalues(
-        bvalues, gradient_directions, delta, Delta, TE=None,
+        bvalues, gradient_directions, delta=None, Delta=None, TE=None,
         min_b_shell_distance=50e6, b0_threshold=10e6):
     r"""
     Creates an acquisition scheme object from bvalues, gradient directions,

--- a/dmipy/core/acquisition_scheme.py
+++ b/dmipy/core/acquisition_scheme.py
@@ -375,7 +375,26 @@ class DmipyAcquisitionScheme:
         plt.ylabel('Gradient Strength [T/m]', fontsize=18)
 
     def return_pruned_acquisition_scheme(self, shell_indices, data=None):
-        "Returns pruned acquisition scheme and optionally also prunes data."
+        """Returns pruned acquisition scheme and optionally also prunes data.
+
+        Parameters
+        ----------
+        shell_indices: list of integers,
+            the shell indices that correspond with the shells that should be
+            returned. For the zeroth and second shell this is e.g. [0, 2]
+        data: NDarray,
+            DW-data that corresponds with the acquisition scheme. If it is
+            given, then the data is pruned the same way as the acquisition
+            scheme, meaning the pruned scheme and data can be used and fitted
+            together again.
+
+        Returns
+        -------
+        pruned_scheme: DmipyAcquisitionScheme object,
+            the pruned acquisition scheme
+        pruned_data: NDarray,
+            the pruned data corresponding to the acquisition scheme.
+        """
         booleans = []
         for index in shell_indices:
             booleans.append(self.shell_indices == index)
@@ -391,11 +410,13 @@ class DmipyAcquisitionScheme:
             TE = None
 
         pruned_scheme = acquisition_scheme_from_bvalues(
-            bvals, gradient_directions, delta, Delta, TE)
+            bvals, gradient_directions, delta, Delta, TE,
+            self.min_b_shell_distance, self.b0_threshold)
         if data is None:
             return pruned_scheme
         else:
-            return pruned_scheme, data[..., mask]
+            pruned_data = data[..., mask]
+            return pruned_scheme, pruned_data
 
 
 class RotationalHarmonicsAcquisitionScheme:

--- a/dmipy/core/acquisition_scheme.py
+++ b/dmipy/core/acquisition_scheme.py
@@ -22,8 +22,8 @@ __all__ = [
     'unify_length_reference_delta_Delta',
     'calculate_shell_bvalues_and_indices',
     'check_acquisition_scheme',
-    'gtab_dipy2mipy',
-    'gtab_mipy2dipy'
+    'gtab_dipy2dmipy',
+    'gtab_dmipy2dipy'
 ]
 
 
@@ -52,21 +52,40 @@ class DmipyAcquisitionScheme:
         self.number_of_b0s = np.sum(self.b0_mask)
         self.number_of_measurements = len(self.bvalues)
         self.gradient_directions = gradient_directions.astype(float)
-        self.qvalues = qvalues.astype(float)
-        self.gradient_strengths = gradient_strengths.astype(float)
-        self.delta = delta.astype(float)
-        self.Delta = Delta.astype(float)
-        self.TE = TE
+        self.qvalues = None
+        if qvalues is not None:
+            self.qvalues = qvalues.astype(float)
+        self.gradient_strengths = None
+        if gradient_strengths is not None:
+            self.gradient_strengths = gradient_strengths.astype(float)
+        self.delta = None
+        if delta is not None:
+            self.delta = delta.astype(float)
+        self.Delta = None
+        if Delta is not None:
+            self.Delta = Delta.astype(float)
+        self.TE = None
         if TE is not None:
             self.TE = TE.astype(float)
-        self.tau = Delta - delta / 3.
+        self.tau = None
+        if self.delta is not None and self.Delta is not None:
+            self.tau = Delta - delta / 3.
         # if there are more then 1 measurement
         if self.number_of_measurements > 1:
             # we check if there are multiple unique delta-Delta combinations
             if self.TE is not None:
                 deltas = np.c_[self.delta, self.Delta, self.TE]
-            else:
+            elif self.delta is not None and self.Delta is not None:
                 deltas = np.c_[self.delta, self.Delta]
+            elif self.delta is None and self.Delta is not None:
+                deltas = np.c_[self.Delta]
+            elif self.delta is not None and self.Delta is None:
+                deltas = np.c_[self.delta]
+            else:
+                deltas = []
+
+            if deltas == []:
+                deltas = np.c_[np.zeros(len(self.bvalues))]
             unique_deltas = np.unique(deltas, axis=0)
             self.shell_indices = np.zeros(len(bvalues), dtype=int)
             self.shell_bvalues = []
@@ -94,12 +113,20 @@ class DmipyAcquisitionScheme:
             first_indices = [
                 np.argmax(self.shell_indices == ind)
                 for ind in np.arange(self.shell_indices.max() + 1)]
-            self.shell_qvalues = self.qvalues[first_indices]
-            self.shell_gradient_strengths = (
-                self.gradient_strengths[first_indices])
-            self.shell_delta = self.delta[first_indices]
-            self.shell_Delta = self.Delta[first_indices]
-            self.shell_TE = self.TE
+            self.shell_qvalues = None
+            if self.qvalues is not None:
+                self.shell_qvalues = self.qvalues[first_indices]
+            self.shell_gradient_strengths = None
+            if self.shell_gradient_strengths is not None:
+                self.shell_gradient_strengths = (
+                    self.gradient_strengths[first_indices])
+            self.shell_delta = None
+            if self.delta is not None:
+                self.shell_delta = self.delta[first_indices]
+            self.shell_Delta = None
+            if self.Delta is not None:
+                self.shell_Delta = self.Delta[first_indices]
+            self.shell_TE = None
             if self.TE is not None:
                 self.shell_TE = self.TE[first_indices]
                 if (len(np.unique(self.TE)) != len(np.unique(
@@ -172,15 +199,9 @@ class DmipyAcquisitionScheme:
         upper_line += " |TE[ms]"
         print(upper_line)
         for ind in np.arange(max(self.shell_indices) + 1):
-            if self.shell_TE is None:
-                print(
-                    "{:<12}|{:<10}|{:<16}|{:<25}|{:<11}|{:<10}|{:<5}".format(
-                        str(ind), sum(self.shell_indices == ind),
-                        int(self.shell_bvalues[ind] / 1e6),
-                        int(1e3 * self.shell_gradient_strengths[ind]),
-                        self.shell_delta[ind] * 1e3,
-                        self.shell_Delta[ind] * 1e3, 'N/A'))
-            else:
+            if (self.shell_TE is not None and
+                self.shell_delta is not None and
+                    self.shell_Delta is not None):
                 print(
                     "{:<12}|{:<10}|{:<16}|{:<25}|{:<11}|{:<10}|{:<5}".format(
                         str(ind), sum(self.shell_indices == ind),
@@ -188,6 +209,40 @@ class DmipyAcquisitionScheme:
                         int(1e3 * self.shell_gradient_strengths[ind]),
                         self.shell_delta[ind] * 1e3,
                         self.shell_Delta[ind] * 1e3, self.shell_TE[ind] * 1e3))
+            elif (self.shell_TE is None and
+                  self.shell_delta is not None and
+                    self.shell_Delta is not None):
+                print(
+                    "{:<12}|{:<10}|{:<16}|{:<25}|{:<11}|{:<10}|{:<5}".format(
+                        str(ind), sum(self.shell_indices == ind),
+                        int(self.shell_bvalues[ind] / 1e6),
+                        int(1e3 * self.shell_gradient_strengths[ind]),
+                        self.shell_delta[ind] * 1e3,
+                        self.shell_Delta[ind] * 1e3, 'N/A'))
+            elif (self.shell_TE is None and
+                  self.shell_delta is None and
+                    self.shell_Delta is not None):
+                print(
+                    "{:<12}|{:<10}|{:<16}|{:<25}|{:<11}|{:<10}|{:<5}".format(
+                        str(ind), sum(self.shell_indices == ind),
+                        int(self.shell_bvalues[ind] / 1e6),
+                        'N/A', 'N/A', self.shell_Delta[ind] * 1e3, 'N/A'))
+            elif (self.shell_TE is None and
+                  self.shell_delta is not None and
+                    self.shell_Delta is None):
+                print(
+                    "{:<12}|{:<10}|{:<16}|{:<25}|{:<11}|{:<10}|{:<5}".format(
+                        str(ind), sum(self.shell_indices == ind),
+                        int(self.shell_bvalues[ind] / 1e6),
+                        'N/A', self.shell_delta[ind] * 1e3, 'N/A', 'N/A'))
+            elif (self.shell_TE is None and
+                  self.shell_delta is None and
+                    self.shell_Delta is None):
+                print(
+                    "{:<12}|{:<10}|{:<16}|{:<25}|{:<11}|{:<10}|{:<5}".format(
+                        str(ind), sum(self.shell_indices == ind),
+                        int(self.shell_bvalues[ind] / 1e6),
+                        'N/A', 'N/A', 'N/A', 'N/A'))
 
     def to_schemefile(self, filename):
         """
@@ -369,31 +424,40 @@ class RotationalHarmonicsAcquisitionScheme:
         angles = np.c_[r, thetas, phis]
         angles_cart = utils.sphere2cart(angles)
 
+        b_all_shells = []
         Gdirs_all_shells = []
-        G_all_shells = []
         delta_all_shells = []
         Delta_all_shells = []
         for shell_index in scheme.unique_dwi_indices:
-            G = scheme.shell_gradient_strengths[shell_index]
-            delta = scheme.shell_delta[shell_index]
-            Delta = scheme.shell_Delta[shell_index]
+            b = scheme.shell_bvalues[shell_index]
+            b_all_shells.append(np.tile(b, N_angular_samples))
+            if scheme.shell_delta is not None:
+                delta = scheme.shell_delta[shell_index]
+                delta_all_shells.append(np.tile(delta, N_angular_samples))
+            if scheme.shell_Delta is not None:
+                Delta = scheme.shell_Delta[shell_index]
+                Delta_all_shells.append(np.tile(Delta, N_angular_samples))
             Gdirs_all_shells.append(angles_cart)
-            G_all_shells.append(np.tile(G, N_angular_samples))
-            delta_all_shells.append(np.tile(delta, N_angular_samples))
-            Delta_all_shells.append(np.tile(Delta, N_angular_samples))
 
+        self.bvalues = np.hstack(b_all_shells)
         self.gradient_directions = np.vstack(Gdirs_all_shells)
-        self.gradient_strengths = np.hstack(G_all_shells)
-        self.delta = np.hstack(delta_all_shells)
-        self.Delta = np.hstack(Delta_all_shells)
-        self.bvalues = b_from_g(
-            self.gradient_strengths,
-            self.delta,
-            self.Delta)
-        self.qvalues = q_from_g(
-            self.gradient_strengths,
-            self.delta)
-        self.tau = self.Delta - self.delta / 3.0
+        self.delta = None
+        if scheme.shell_delta is not None:
+            self.delta = np.hstack(delta_all_shells)
+        self.Delta = None
+        if scheme.shell_Delta is not None:
+            self.Delta = np.hstack(Delta_all_shells)
+        if self.delta is not None and self.Delta is not None:
+            self.gradient_strengths = g_from_b(
+                self.bvalues,
+                self.delta,
+                self.Delta)
+            self.qvalues = q_from_g(
+                self.gradient_strengths,
+                self.delta)
+            self.tau = self.Delta - self.delta / 3.0
+        else:
+            self.gradient_strengths = self.qvalues = self.tau = None
         self.b0_mask = np.tile(False, len(self.bvalues))
         self.shell_delta = scheme.shell_delta
         self.shell_Delta = scheme.shell_Delta
@@ -459,8 +523,11 @@ def acquisition_scheme_from_bvalues(
         bvalues, delta, Delta, TE)
     check_acquisition_scheme(
         bvalues, gradient_directions, delta_, Delta_, TE_)
-    qvalues = q_from_b(bvalues, delta_, Delta_)
-    gradient_strengths = g_from_b(bvalues, delta_, Delta_)
+    if delta is not None and Delta is not None:
+        qvalues = q_from_b(bvalues, delta_, Delta_)
+        gradient_strengths = g_from_b(bvalues, delta_, Delta_)
+    else:
+        qvalues = gradient_strengths = None
     return DmipyAcquisitionScheme(bvalues, gradient_directions, qvalues,
                                   gradient_strengths, delta_, Delta_, TE_,
                                   min_b_shell_distance, b0_threshold)
@@ -565,6 +632,12 @@ def acquisition_scheme_from_schemefile(
     ----------
     file_path: string
         absolute file path to schemefile location
+    min_b_shell_distance : float
+        minimum bvalue distance between different shells. This parameter is
+        used to separate measurements into different shells, which is necessary
+        for any model using spherical convolution or spherical mean.
+    b0_threshold : float
+        bvalue threshold for a measurement to be considered a b0 measurement.
 
     Returns
     -------
@@ -615,16 +688,20 @@ def unify_length_reference_delta_Delta(reference_array, delta, Delta, TE):
     TE_ : None or array of size (Nsamples)
         Echo time copied to be same size as reference_array
     """
-    if isinstance(delta, float) or isinstance(delta, int):
+    if delta is None:
+        delta_ = delta
+    elif isinstance(delta, float) or isinstance(delta, int):
         delta_ = np.tile(delta, len(reference_array))
     else:
         delta_ = delta.copy()
-    if isinstance(Delta, float) or isinstance(Delta, int):
+    if Delta is None:
+        Delta_ = Delta
+    elif isinstance(Delta, float) or isinstance(Delta, int):
         Delta_ = np.tile(Delta, len(reference_array))
     else:
         Delta_ = Delta.copy()
     if TE is None:
-        TE_ = None
+        TE_ = TE
     elif isinstance(TE, float) or isinstance(TE, int):
         TE_ = np.tile(TE, len(reference_array))
     else:
@@ -688,24 +765,45 @@ def check_acquisition_scheme(
             len(bqg_values), len(gradient_directions)
         )
         raise ValueError(msg)
-    if len(bqg_values) != len(delta) or len(bqg_values) != len(Delta):
-        msg = "b/q/G input, delta and Delta must have the same length. "
-        msg += "Currently their lengths are {}, {} and {}.".format(
-            len(bqg_values), len(delta), len(Delta)
-        )
-        raise ValueError(msg)
-    if delta.ndim > 1 or Delta.ndim > 1:
-        msg = "delta and Delta must be one-dimensional arrays. "
-        msg += "Currently their dimensions are {} and {}.".format(
-            delta.ndim, Delta.ndim
-        )
-        raise ValueError(msg)
-    if np.min(delta) < 0 or np.min(Delta) < 0:
-        msg = "delta and Delta must be zero or positive. "
-        msg += "Currently their minimum values are {} and {}.".format(
-            np.min(delta), np.min(Delta)
-        )
-        raise ValueError(msg)
+    if delta is not None:
+        if len(bqg_values) != len(delta):
+            msg = "b/q/G input and delta must have the same length. "
+            msg += "Currently their lengths are {} and {}.".format(
+                len(bqg_values), len(delta)
+            )
+            raise ValueError(msg)
+        if delta.ndim > 1:
+            msg = "delta must be one-dimensional array. "
+            msg += "Currently its dimension is {}".format(
+                delta.ndim
+            )
+            raise ValueError(msg)
+        if np.min(delta) < 0:
+            msg = "delta must be zero or positive. "
+            msg += "Currently its minimum value is {}.".format(
+                np.min(delta)
+            )
+            raise ValueError(msg)
+    if Delta is not None:
+        if len(bqg_values) != len(Delta):
+            msg = "b/q/G input and Delta must have the same length. "
+            msg += "Currently their lengths are {} and {}.".format(
+                len(bqg_values), len(Delta)
+            )
+            raise ValueError(msg)
+        if Delta.ndim > 1:
+            msg = "Delta must be one-dimensional array. "
+            msg += "Currently its dimension is {}.".format(
+                Delta.ndim
+            )
+            raise ValueError(msg)
+        if np.min(Delta) < 0:
+            msg = "Delta must be zero or positive. "
+            msg += "Currently its minimum value is {}.".format(
+                np.min(Delta)
+            )
+            raise ValueError(msg)
+
     if gradient_directions.ndim != 2 or gradient_directions.shape[1] != 3:
         msg = "gradient_directions n must be two dimensional array of shape "
         msg += "[N, 3]. Currently its shape is {}.".format(
@@ -727,37 +825,68 @@ def check_acquisition_scheme(
         )
 
 
-def gtab_dipy2dmipy(dipy_gradient_table, dummy_deltas=False, **kwargs):
-    "Converts a dipy gradient_table to a dmipy acquisition_scheme."
+def gtab_dipy2dmipy(dipy_gradient_table, min_b_shell_distance=50e6,
+                    b0_threshold=10e6):
+    """Converts a dipy gradient_table to a dmipy acquisition_scheme.
+    If no big_delta or small_delta is defined in the gradient table, then None
+    is passed to the DmipyAcquisitionScheme for these fields, and no models
+    can be used that need this information.
+
+    Parameters
+    ----------
+    dipy_gradient_table: dipy GradientTable instance,
+        object that contains bvals, bvecs, pulse separation and duration
+        information.
+    min_b_shell_distance : float
+        minimum bvalue distance between different shells. This parameter is
+        used to separate measurements into different shells, which is necessary
+        for any model using spherical convolution or spherical mean.
+    b0_threshold : float
+        bvalue threshold for a measurement to be considered a b0 measurement.
+
+    Returns
+    -------
+    DmipyAcquisitionScheme: acquisition scheme object
+        contains all information of the acquisition scheme to be used in any
+        microstructure model.
+
+    """
     if not isinstance(dipy_gradient_table, GradientTable):
         msg = "Input must be a dipy GradientTable object. "
         raise ValueError(msg)
     bvals = dipy_gradient_table.bvals * 1e6
     bvecs = dipy_gradient_table.bvecs
-    if not dummy_deltas:
-        if (dipy_gradient_table.small_delta is None or
-                dipy_gradient_table.big_delta is None):
-            msg = "Dmipy acquisition schemes need non-None pulse duration and "
-            msg += "separation (small- and big Delta). If these are not known "
-            msg += "for your acquisition, set `dummy_deltas=True` to assume "
-            msg += "these are typical values Delta=30ms and delta=10ms.\n\n"
-            msg += "But BE AWARE, this this will bias estimation with "
-            msg += "models that use delta/Delta for signal generation."
-            raise ValueError(msg)
-        else:
-            delta = dipy_gradient_table.small_delta
-            Delta = dipy_gradient_table.big_delta
-    else:
-        delta = 0.01  # 10ms
-        Delta = 0.03  # 30ms
+    delta = dipy_gradient_table.small_delta
+    Delta = dipy_gradient_table.big_delta
+
+    if delta is None or Delta is None:
+        msg = "pulse_separation (big_delta) or pulse_duration (small_delta) "
+        msg += "are not defined in the Dipy gtab. This means the resulting "
+        msg += "DmipyAcquisitionScheme cannot be used with CompartmentModels "
+        msg += "that need these."
+        warn(msg)
+
     gtab_dmipy = acquisition_scheme_from_bvalues(
         bvalues=bvals, gradient_directions=bvecs, delta=delta, Delta=Delta,
-        **kwargs)
+        min_b_shell_distance=min_b_shell_distance, b0_threshold=b0_threshold)
     return gtab_dmipy
 
 
 def gtab_dmipy2dipy(dmipy_gradient_table):
-    "Converts a dmipy acquisition scheme to a dipy gradient_table."
+    """Converts a dmipy acquisition scheme to a dipy gradient_table.
+
+    Parameters
+    ----------
+    DmipyAcquisitionScheme: acquisition scheme object
+        contains all information of the acquisition scheme to be used in any
+        microstructure model.
+
+    Returns
+    -------
+    dipy_gradient_table: dipy GradientTable instance,
+        object that contains bvals, bvecs, pulse separation and duration
+        information.
+    """
     if not isinstance(dmipy_gradient_table, DmipyAcquisitionScheme):
         msg = "Input must be a DmipyAcquisitionScheme object. "
         raise ValueError(msg)
@@ -768,8 +897,16 @@ def gtab_dmipy2dipy(dmipy_gradient_table):
 
     if len(np.unique(delta)) == 1:
         delta = delta[0]
+    elif len(np.unique(delta)) > 1:
+        msg = "Cannot create Dipy GradientTable for Acquisition schemes with "
+        msg += "multiple delta (pulse duration) values, due to current "
+        msg += "limitations of Dipy GradientTables."
     if len(np.unique(Delta)) == 1:
         Delta = Delta[0]
-    gtab_dipy = gradient_table(
+    elif len(np.unique(Delta)) > 1:
+        msg = "Cannot create Dipy GradientTable for Acquisition schemes with "
+        msg += "multiple Delta (pulse sepration) values, due to current "
+        msg += "limitations of Dipy GradientTables."
+    dipy_gradient_table = gradient_table(
         bvals=bvals, bvecs=bvecs, small_delta=delta, big_delta=Delta)
-    return gtab_dipy
+    return dipy_gradient_table

--- a/dmipy/core/acquisition_scheme.py
+++ b/dmipy/core/acquisition_scheme.py
@@ -268,46 +268,6 @@ class DmipyAcquisitionScheme:
         np.savetxt(filename, schemefile_data,
                    header=header, comments='')
 
-    def _rotational_harmonics_acquisition_scheme(
-            self, angular_samples=10):
-        """
-        Calculates the acquisition scheme to return all the samples required to
-        estimate the rotational harmonics of all the shells at once.
-
-        Parameters
-        ----------
-        angular_samples: integer
-            the number of angular samples that are sampled per shell.
-        """
-        thetas = np.linspace(0, np.pi / 2, angular_samples)
-        r = np.ones(angular_samples)
-        phis = np.zeros(angular_samples)
-        angles = np.c_[r, thetas, phis]
-        angles_cart = utils.sphere2cart(angles)
-
-        Gdirs_all_shells = []
-        G_all_shells = []
-        delta_all_shells = []
-        Delta_all_shells = []
-        for G, delta, Delta in zip(self.shell_gradient_strengths,
-                                   self.shell_delta, self.shell_Delta):
-            Gdirs_all_shells.append(angles_cart)
-            G_all_shells.append(np.tile(G, angular_samples))
-            delta_all_shells.append(np.tile(delta, angular_samples))
-            Delta_all_shells.append(np.tile(Delta, angular_samples))
-        self.rh_acquisition_scheme = (
-            acquisition_scheme_from_gradient_strengths(
-                gradient_strengths=np.hstack(G_all_shells),
-                gradient_directions=np.vstack(Gdirs_all_shells),
-                delta=np.hstack(delta_all_shells),
-                Delta=np.hstack(Delta_all_shells))
-        )
-        self.inverse_rh_matrix = {
-            rh_order: np.linalg.pinv(real_sym_rh_basis(
-                rh_order, thetas, phis
-            )) for rh_order in np.arange(0, 15, 2)
-        }
-
     def visualise_acquisition_G_Delta_rainbow(
             self,
             Delta_start=None, Delta_end=None, G_start=None, G_end=None,

--- a/dmipy/core/fitted_modeling_framework.py
+++ b/dmipy/core/fitted_modeling_framework.py
@@ -174,6 +174,9 @@ class FittedMultiCompartmentModel:
         """
         if acquisition_scheme is None:
             acquisition_scheme = self.model.scheme
+        self.model._check_model_params_with_acquisition_params(
+            acquisition_scheme)
+
         dataset_shape = self.fitted_parameters_vector.shape[:-1]
         if S0 is None:
             S0 = self.S0
@@ -284,6 +287,9 @@ class FittedMultiCompartmentSphericalMeanModel:
         """
         if acquisition_scheme is None:
             acquisition_scheme = self.model.scheme
+        self.model._check_model_params_with_acquisition_params(
+            acquisition_scheme)
+
         dataset_shape = self.fitted_parameters_vector.shape[:-1]
         if S0 is None:
             S0 = self.S0
@@ -737,6 +743,9 @@ class FittedMultiCompartmentSphericalHarmonicsModel:
         """
         if acquisition_scheme is None:
             acquisition_scheme = self.model.scheme
+        self.model._check_model_params_with_acquisition_params(
+            acquisition_scheme)
+
         dataset_shape = self.fitted_parameters_vector.shape[:-1]
         if S0 is None:
             if self.fit_S0_response:

--- a/dmipy/core/modeling_framework.py
+++ b/dmipy/core/modeling_framework.py
@@ -711,7 +711,7 @@ class MultiCompartmentModelProperties:
     def _check_model_params_with_acquisition_params(self, acquisition_scheme):
         for model in self.models:
             for parameter in model._required_acquisition_parameters:
-                if acquisition_scheme.parameter is None:
+                if getattr(acquisition_scheme, parameter) is None:
                     msg = "{} is not compatible with ".format(model.__name__)
                     msg += "given acquisition scheme because it needs "
                     msg += "{} as an acquisition parameter.".format(parameter)

--- a/dmipy/core/modeling_framework.py
+++ b/dmipy/core/modeling_framework.py
@@ -1743,6 +1743,7 @@ class MultiCompartmentSphericalHarmonicsModel(MultiCompartmentModelProperties):
             Resonance in Medicine 58.3 (2007): 497-510.
         """
         self._check_if_kernel_parameters_are_fixed()
+        self._check_tissue_model_acquisition_scheme(acquisition_scheme)
         self._check_model_params_with_acquisition_params(acquisition_scheme)
 
         self.voxel_varying_kernel = False

--- a/dmipy/core/modeling_framework.py
+++ b/dmipy/core/modeling_framework.py
@@ -712,7 +712,8 @@ class MultiCompartmentModelProperties:
         for model in self.models:
             for parameter in model._required_acquisition_parameters:
                 if getattr(acquisition_scheme, parameter) is None:
-                    msg = "{} is not compatible with ".format(model.__name__)
+                    msg = "{} is not compatible with ".format(
+                        model.__class__.__name__)
                     msg += "given acquisition scheme because it needs "
                     msg += "{} as an acquisition parameter.".format(parameter)
                     raise ValueError(msg)

--- a/dmipy/core/modeling_framework.py
+++ b/dmipy/core/modeling_framework.py
@@ -708,6 +708,15 @@ class MultiCompartmentModelProperties:
         self._inverted_parameter_map.update(
             {(None, 'fraction'): parameter_name})
 
+    def _check_model_params_with_acquisition_params(self, acquisition_scheme):
+        for model in self.models:
+            for parameter in model._required_acquisition_parameters:
+                if acquisition_scheme.parameter is None:
+                    msg = "{} is not compatible with ".format(model.__name__)
+                    msg += "given acquisition scheme because it needs "
+                    msg += "{} as an acquisition parameter.".format(parameter)
+                    raise ValueError(msg)
+
     def visualize_model_setup(
             self, view=True, cleanup=True, with_parameters=False,
             im_format='png'):
@@ -956,6 +965,7 @@ class MultiCompartmentModel(MultiCompartmentModelProperties):
             functions.
         """
         self._check_tissue_model_acquisition_scheme(acquisition_scheme)
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
 
         # estimate S0
         self.scheme = acquisition_scheme
@@ -1068,6 +1078,8 @@ class MultiCompartmentModel(MultiCompartmentModelProperties):
             array the same size as x0.
             The simulated signal of the microstructure model.
         """
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
+
         Ndata = acquisition_scheme.number_of_measurements
         if isinstance(parameters_array_or_dict, np.ndarray):
             x0 = parameters_array_or_dict
@@ -1318,6 +1330,7 @@ class MultiCompartmentSphericalMeanModel(MultiCompartmentModelProperties):
             functions.
         """
         self._check_tissue_model_acquisition_scheme(acquisition_scheme)
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
 
         # estimate S0
         self.scheme = acquisition_scheme
@@ -1443,6 +1456,8 @@ class MultiCompartmentSphericalMeanModel(MultiCompartmentModelProperties):
             array the same size as x0.
             The simulated signal of the microstructure model.
         """
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
+
         Ndata = acquisition_scheme.shell_indices.max() + 1
         if isinstance(parameters_array_or_dict, np.ndarray):
             x0 = parameters_array_or_dict
@@ -1728,7 +1743,7 @@ class MultiCompartmentSphericalHarmonicsModel(MultiCompartmentModelProperties):
             Resonance in Medicine 58.3 (2007): 497-510.
         """
         self._check_if_kernel_parameters_are_fixed()
-        self._check_tissue_model_acquisition_scheme(acquisition_scheme)
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
 
         self.voxel_varying_kernel = False
         if bool(self.x0_parameters):  # if the dictionary is not empty
@@ -1897,6 +1912,8 @@ class MultiCompartmentSphericalHarmonicsModel(MultiCompartmentModelProperties):
             array the same size as x0.
             The simulated signal of the microstructure model.
         """
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
+
         Ndata = acquisition_scheme.number_of_measurements
         if isinstance(parameters_array_or_dict, np.ndarray):
             x0 = parameters_array_or_dict

--- a/dmipy/core/tests/test_acquisition_scheme.py
+++ b/dmipy/core/tests/test_acquisition_scheme.py
@@ -1,12 +1,17 @@
 import numpy as np
 from dmipy.data.saved_acquisition_schemes import (
-    duval_cat_spinal_cord_2d_acquisition_scheme)
+    duval_cat_spinal_cord_2d_acquisition_scheme,
+    wu_minn_hcp_acquisition_scheme)
 from dmipy.core.acquisition_scheme import (
     acquisition_scheme_from_bvalues,
     acquisition_scheme_from_qvalues,
     acquisition_scheme_from_gradient_strengths,
     calculate_shell_bvalues_and_indices,
     gtab_dipy2dmipy, gtab_dmipy2dipy)
+from dmipy.core.modeling_framework import (
+    MultiCompartmentModel)
+from dmipy.signal_models.cylinder_models import (
+    C4CylinderGaussianPhaseApproximation)
 from dipy.core.gradients import gradient_table
 from numpy.testing import (
     assert_raises, assert_equal, assert_array_equal)
@@ -201,3 +206,27 @@ def test_acquisition_scheme_summary(Nsamples=10):
 def test_raise_dmipy2dmipy_multiple_delta_Delta():
     scheme = duval_cat_spinal_cord_2d_acquisition_scheme()
     assert_raises(ValueError, gtab_dmipy2dipy, scheme)
+
+
+def test_acquisition_scheme_pruning():
+    scheme = wu_minn_hcp_acquisition_scheme()
+    test_data = np.random.rand(len(scheme.bvalues))
+
+    scheme_pr, data_pr = scheme.return_pruned_acquisition_scheme(
+        [2], test_data)
+    assert_array_equal(
+        scheme_pr.bvalues,
+        scheme.bvalues[scheme.shell_indices == 2])
+    assert_array_equal(
+        data_pr,
+        test_data[scheme.shell_indices == 2])
+
+
+def test_acq_scheme_without_deltas_model_catch():
+    scheme = wu_minn_hcp_acquisition_scheme()
+    test_data = np.random.rand(len(scheme.bvalues))
+    scheme_clinical = acquisition_scheme_from_bvalues(
+        scheme.bvalues, scheme.gradient_directions)
+    mc_model = MultiCompartmentModel(
+        [C4CylinderGaussianPhaseApproximation()])
+    assert_raises(ValueError, mc_model.fit, scheme_clinical, test_data)

--- a/dmipy/core/tests/test_acquisition_scheme.py
+++ b/dmipy/core/tests/test_acquisition_scheme.py
@@ -1,4 +1,6 @@
 import numpy as np
+from dmipy.data.saved_acquisition_schemes import (
+    duval_cat_spinal_cord_2d_acquisition_scheme)
 from dmipy.core.acquisition_scheme import (
     acquisition_scheme_from_bvalues,
     acquisition_scheme_from_qvalues,
@@ -143,7 +145,7 @@ def test_estimate_shell_indices():
     assert_array_equal(shell_indices, bvalues)
 
 
-def test_shell_indices_with_vayring_diffusion_times(Nsamples=10):
+def test_shell_indices_with_varying_diffusion_times(Nsamples=10):
     # tests whether measurements with the same bvalue but different diffusion
     # time are correctly classified in different shells
     bvalues = np.tile(1e9, Nsamples)
@@ -156,7 +158,7 @@ def test_shell_indices_with_vayring_diffusion_times(Nsamples=10):
     assert_equal(len(np.unique(scheme.shell_indices)), 2)
 
 
-def test_dipy2mipy_acquisition_converter(Nsamples=10):
+def test_dipy2dmipy_acquisition_converter(Nsamples=10):
     bvals = np.tile(1e3, Nsamples)
     bvecs = np.tile(np.r_[1., 0., 0.], (Nsamples, 1))
     big_delta = 0.03
@@ -170,7 +172,7 @@ def test_dipy2mipy_acquisition_converter(Nsamples=10):
     assert_equal(np.unique(gtab_mipy.delta), gtab_dipy.small_delta)
 
 
-def test_mipy2dipy_acquisition_converter(Nsamples=10):
+def test_dmipy2dipy_acquisition_converter(Nsamples=10):
     bvals = np.tile(1e9, Nsamples)
     bvecs = np.tile(np.r_[1., 0., 0.], (Nsamples, 1))
     big_delta = 0.03
@@ -194,3 +196,8 @@ def test_acquisition_scheme_summary(Nsamples=10):
         bvalues=bvals, gradient_directions=bvecs,
         delta=small_delta, Delta=big_delta)
     gtab_mipy.print_acquisition_info
+
+
+def test_raise_dmipy2dmipy_multiple_delta_Delta():
+    scheme = duval_cat_spinal_cord_2d_acquisition_scheme()
+    assert_raises(ValueError, gtab_dmipy2dipy, scheme)

--- a/dmipy/core/tests/test_acquisition_scheme.py
+++ b/dmipy/core/tests/test_acquisition_scheme.py
@@ -4,7 +4,7 @@ from dmipy.core.acquisition_scheme import (
     acquisition_scheme_from_qvalues,
     acquisition_scheme_from_gradient_strengths,
     calculate_shell_bvalues_and_indices,
-    gtab_dipy2mipy, gtab_mipy2dipy)
+    gtab_dipy2dmipy, gtab_dmipy2dipy)
 from dipy.core.gradients import gradient_table
 from numpy.testing import (
     assert_raises, assert_equal, assert_array_equal)
@@ -163,7 +163,7 @@ def test_dipy2mipy_acquisition_converter(Nsamples=10):
     small_delta = 0.01
     gtab_dipy = gradient_table(
         bvals=bvals, bvecs=bvecs, small_delta=small_delta, big_delta=big_delta)
-    gtab_mipy = gtab_dipy2mipy(gtab_dipy)
+    gtab_mipy = gtab_dipy2dmipy(gtab_dipy)
     assert_array_equal(gtab_mipy.bvalues / 1e6, gtab_dipy.bvals)
     assert_array_equal(gtab_mipy.gradient_directions, gtab_dipy.bvecs)
     assert_equal(np.unique(gtab_mipy.Delta), gtab_dipy.big_delta)
@@ -178,7 +178,7 @@ def test_mipy2dipy_acquisition_converter(Nsamples=10):
     gtab_mipy = acquisition_scheme_from_bvalues(
         bvalues=bvals, gradient_directions=bvecs,
         delta=small_delta, Delta=big_delta)
-    gtab_dipy = gtab_mipy2dipy(gtab_mipy)
+    gtab_dipy = gtab_dmipy2dipy(gtab_mipy)
     assert_array_equal(gtab_mipy.bvalues / 1e6, gtab_dipy.bvals)
     assert_array_equal(gtab_mipy.gradient_directions, gtab_dipy.bvecs)
     assert_equal(gtab_mipy.Delta, gtab_dipy.big_delta)

--- a/dmipy/distributions/distribute_models.py
+++ b/dmipy/distributions/distribute_models.py
@@ -356,6 +356,14 @@ class DistributedModel:
         """
         return copy.copy(self)
 
+    def _set_required_acquisition_parameters(self):
+        self._required_acquisition_parameters = []
+        for model in self.models:
+            self._required_acquisition_parameters += (
+                model._required_acquisition_parameters)
+        self._required_acquisition_parameters = np.unique(
+            self._required_acquisition_parameters)
+
     @property
     def parameter_names(self):
         "Retuns the DistributedModel parameter names."
@@ -584,6 +592,7 @@ class SD1WatsonDistributed(DistributedModel):
 
     def __init__(self, models, parameter_links=None):
         self.models = models
+        self._set_required_acquisition_parameters()
         self._check_for_double_model_class_instances()
         self._check_for_dispersable_models()
 
@@ -622,6 +631,7 @@ class SD2BinghamDistributed(DistributedModel):
 
     def __init__(self, models, parameter_links=None):
         self.models = models
+        self._set_required_acquisition_parameters()
         self._check_for_double_model_class_instances()
         self._check_for_dispersable_models()
 
@@ -661,6 +671,7 @@ class DD1GammaDistributed(DistributedModel):
     def __init__(self, models, parameter_links=None,
                  target_parameter='diameter'):
         self.models = models
+        self._set_required_acquisition_parameters()
         self.target_parameter = target_parameter
         self._check_for_double_model_class_instances()
         self._check_for_distributable_models()

--- a/dmipy/distributions/distribute_models.py
+++ b/dmipy/distributions/distribute_models.py
@@ -362,7 +362,7 @@ class DistributedModel:
             self._required_acquisition_parameters += (
                 model._required_acquisition_parameters)
         self._required_acquisition_parameters = np.unique(
-            self._required_acquisition_parameters)
+            self._required_acquisition_parameters).tolist()
 
     @property
     def parameter_names(self):

--- a/dmipy/signal_models/capped_cylinder_models.py
+++ b/dmipy/signal_models/capped_cylinder_models.py
@@ -37,7 +37,7 @@ class CC2CappedCylinderStejskalTannerApproximation(ModelProperties):
         spheres and between planes." Journal of Magnetic Resonance, Series A
         104.1 (1993): 17-25.
     """
-
+    _required_acquisition_parameters = ['gradient_directions', 'qvalues']
     _model_type = 'CompartmentModel'
 
     def __init__(
@@ -146,7 +146,8 @@ class CC3CappedCylinderCallaghanApproximation(ModelProperties):
         relaxation." Journal of magnetic resonance, Series A 113.1 (1995):
         53-59.
     """
-
+    _required_acquisition_parameters = [
+        'gradient_directions', 'qvalues', 'tau']
     _model_type = 'CompartmentModel'
 
     def __init__(

--- a/dmipy/signal_models/cylinder_models.py
+++ b/dmipy/signal_models/cylinder_models.py
@@ -45,6 +45,8 @@ class C1Stick(ModelProperties):
            Magnetic Resonance in Medicine (2003)
     """
 
+    _required_acquisition_parameters = ['bvalues', 'gradient_directions']
+
     _parameter_ranges = {
         'mu': ([0, np.pi], [-np.pi, np.pi]),
         'lambda_par': (.1, 3)
@@ -181,6 +183,9 @@ class C2CylinderStejskalTannerApproximation(ModelProperties):
             cylindrical geometry." Journal of Magnetic Resonance, Series A
             117.1 (1995): 94-97.
     """
+
+    _required_acquisition_parameters = [
+        'bvalues', 'gradient_directions', 'qvalues']
 
     _parameter_ranges = {
         'mu': ([0, np.pi], [-np.pi, np.pi]),
@@ -346,6 +351,9 @@ class C3CylinderCallaghanApproximation(ModelProperties):
             53-59.
     """
 
+    _required_acquisition_parameters = [
+        'bvalues', 'gradient_directions', 'qvalues', 'tau']
+
     _parameter_ranges = {
         'mu': ([0, np.pi], [-np.pi, np.pi]),
         'lambda_par': (.1, 3),
@@ -436,9 +444,7 @@ class C3CylinderCallaghanApproximation(ModelProperties):
         bvals = acquisition_scheme.bvalues
         n = acquisition_scheme.gradient_directions
         q = acquisition_scheme.qvalues
-        Delta = acquisition_scheme.Delta
-        delta = acquisition_scheme.delta
-        tau = Delta - delta / 3.0
+        tau = acquisition_scheme.tau
 
         diameter = kwargs.get('diameter', self.diameter)
         lambda_par = kwargs.get('lambda_par', self.lambda_par)
@@ -541,6 +547,10 @@ class C4CylinderGaussianPhaseApproximation(ModelProperties):
             Cylinders. Phosphocreatine in Rabbit Leg Muscle"
             Journal of Magnetic Resonance Series B (1994)
     """
+
+    _required_acquisition_parameters = [
+        'bvalues', 'gradient_directions',
+        'gradient_strengths', 'delta', 'Delta']
 
     _parameter_ranges = {
         'mu': ([0, np.pi], [-np.pi, np.pi]),

--- a/dmipy/signal_models/gaussian_models.py
+++ b/dmipy/signal_models/gaussian_models.py
@@ -38,6 +38,7 @@ class G1Ball(ModelProperties):
             diffusion-weighted MR imaging"
            Magnetic Resonance in Medicine (2003)
     """
+    _required_acquisition_parameters = ['bvalues']
 
     _parameter_ranges = {
         'lambda_iso': (.1, 3)
@@ -151,6 +152,7 @@ class G2Zeppelin(ModelProperties):
            "Compartment models of the diffusion MR signal in brain white
             matter: a taxonomy and comparison". NeuroImage (2012)
     """
+    _required_acquisition_parameters = ['bvalues', 'gradient_directions']
 
     _parameter_ranges = {
         'mu': ([0, np.pi], [-np.pi, np.pi]),
@@ -304,6 +306,8 @@ class G3TemporalZeppelin(ModelProperties):
         structure of neuronal tracts from time-dependent diffusion.
         NeuroImage 114, 18.
     """
+    _required_acquisition_parameters = [
+        'bvalues', 'gradient_directions', 'delta', 'Delta']
 
     _parameter_ranges = {
         'mu': ([0, np.pi], [-np.pi, np.pi]),

--- a/dmipy/signal_models/plane_models.py
+++ b/dmipy/signal_models/plane_models.py
@@ -24,6 +24,7 @@ class P2PlaneStejskalTannerApproximation(ModelProperties):
         spheres and between planes." Journal of Magnetic Resonance, Series A
         104.1 (1993): 17-25.
     """
+    _required_acquisition_parameters = ['qvalues']
     _parameter_ranges = {
         'diameter': (1e-2, 20)
     }
@@ -92,6 +93,7 @@ class P3PlaneCallaghanApproximation(ModelProperties):
     [1] Callaghan, "Pulsed-Gradient Spin-Echo NMR for Planar, Cylindrical,
         and Spherical Pores under Conditions of Wall Relaxation", JMR 1995
     """
+    _required_acquisition_parameters = ['qvalues', 'tau']
 
     _parameter_ranges = {
         'diameter': (1e-2, 20)

--- a/dmipy/signal_models/sphere_models.py
+++ b/dmipy/signal_models/sphere_models.py
@@ -22,6 +22,7 @@ class S1Dot(ModelProperties):
            "Compartment models of the diffusion MR signal in brain white
             matter: a taxonomy and comparison". NeuroImage (2012)
     """
+    _required_acquisition_parameters = []
 
     _parameter_ranges = {
     }
@@ -119,6 +120,8 @@ class S2SphereStejskalTannerApproximation(ModelProperties):
         spheres and between planes." Journal of Magnetic Resonance, Series A
         104.1 (1993): 17-25.
     """
+    _required_acquisition_parameters = ['qvalues']
+
     _parameter_ranges = {
         'diameter': (1e-2, 20)
     }
@@ -241,6 +244,7 @@ class _S3SphereCallaghanApproximation(ModelProperties):
     [1] Callaghan, "Pulsed-Gradient Spin-Echo NMR for Planar, Cylindrical,
         and Spherical Pores under Conditions of Wall Relaxation", JMR 1995
     """
+    _required_acquisition_parameters = ['qvalues', 'tau']
 
     _parameter_ranges = {
         'diameter': (1e-2, 20)
@@ -333,6 +337,8 @@ class S4SphereGaussianPhaseApproximation(ModelProperties):
         spheres and between planes." Journal of Magnetic Resonance, Series A
         104.1 (1993): 17-25.
     """
+    _required_acquisition_parameters = ['gradient_strengths', 'delta', 'Delta']
+
     _parameter_ranges = {
         'diameter': (1e-2, 20)
     }

--- a/dmipy/signal_models/tissue_response_models.py
+++ b/dmipy/signal_models/tissue_response_models.py
@@ -3,7 +3,7 @@ from dmipy.utils.utils import cart2mu
 from dmipy.utils.spherical_convolution import real_sym_rh_basis
 from ..core.modeling_framework import ModelProperties
 from ..utils import utils
-from dmipy.core.acquisition_scheme import gtab_mipy2dipy
+from dmipy.core.acquisition_scheme import gtab_dmipy2dipy
 from dipy.reconst import dti
 
 
@@ -50,7 +50,7 @@ class AnisotropicTissueResponseModel(ModelProperties):
     def __init__(self, acquisition_scheme, data, mu=None):
         self.acquisition_scheme = acquisition_scheme
         self.mu = mu
-        gtab = gtab_mipy2dipy(acquisition_scheme)
+        gtab = gtab_dmipy2dipy(acquisition_scheme)
         tenmod = dti.TensorModel(gtab)
         tenfit = tenmod.fit(data)
         evecs = tenfit.evecs

--- a/dmipy/signal_models/tissue_response_models.py
+++ b/dmipy/signal_models/tissue_response_models.py
@@ -42,6 +42,7 @@ class AnisotropicTissueResponseModel(ModelProperties):
         directions for high-angular-resolution diffusion-weighted imaging."
         NMR in Biomedicine 26.12 (2013): 1775-1786.
     """
+    _required_acquisition_parameters = []
     _parameter_ranges = {'mu': ([0, np.pi], [-np.pi, np.pi])}
     _parameter_scales = {'mu': np.r_[1., 1.]}
     _parameter_types = {'mu': 'orientation'}
@@ -210,6 +211,7 @@ class IsotropicTissueResponseModel(ModelProperties):
         directions for high-angular-resolution diffusion-weighted imaging."
         NMR in Biomedicine 26.12 (2013): 1775-1786.
     """
+    _required_acquisition_parameters = []
     _parameter_ranges = {}
     _parameter_scales = {}
     _parameter_types = {}

--- a/dmipy/tissue_response/three_tissue_response.py
+++ b/dmipy/tissue_response/three_tissue_response.py
@@ -2,7 +2,7 @@ from scipy.optimize import brute
 from scipy.stats import pearsonr
 import numpy as np
 from dipy.reconst import dti
-from ..core.acquisition_scheme import gtab_mipy2dipy
+from ..core.acquisition_scheme import gtab_dmipy2dipy
 from dipy.segment.mask import median_otsu
 from . import white_matter_response
 from ..signal_models.tissue_response_models import IsotropicTissueResponseModel
@@ -81,7 +81,7 @@ def three_tissue_response_dhollander16(
 
     # Make Mask
     b0_mask, mask = median_otsu(data, 2, 1)
-    gtab = gtab_mipy2dipy(acquisition_scheme)
+    gtab = gtab_dmipy2dipy(acquisition_scheme)
     tenmod = dti.TensorModel(gtab)
     tenfit = tenmod.fit(b0_mask)
     fa = tenfit.fa

--- a/dmipy/tissue_response/white_matter_response.py
+++ b/dmipy/tissue_response/white_matter_response.py
@@ -1,5 +1,5 @@
 from dipy.reconst import dti
-from ..core.acquisition_scheme import gtab_mipy2dipy
+from ..core.acquisition_scheme import gtab_dmipy2dipy
 from ..core.modeling_framework import (
     MultiCompartmentSphericalHarmonicsModel)
 import numpy as np
@@ -58,7 +58,7 @@ def white_matter_response_tournier07(
         # assume the data was prepared.
         data_to_fit = data.reshape([-1, data_shape[-1]])
 
-    gtab = gtab_mipy2dipy(acquisition_scheme)
+    gtab = gtab_dmipy2dipy(acquisition_scheme)
     tenmod = dti.TensorModel(gtab)
     tenfit = tenmod.fit(data_to_fit)
     fa = tenfit.fa
@@ -158,7 +158,7 @@ def white_matter_response_tournier13(
         # assume the data was prepared.
         data_to_fit = data.reshape([-1, data_shape[-1]])
 
-    gtab = gtab_mipy2dipy(acquisition_scheme)
+    gtab = gtab_dmipy2dipy(acquisition_scheme)
     tenmod = dti.TensorModel(gtab)
     tenfit = tenmod.fit(data_to_fit)
     fa = tenfit.fa

--- a/examples/example_multi_compartment_constrained_spherical_deconvolution.ipynb
+++ b/examples/example_multi_compartment_constrained_spherical_deconvolution.ipynb
@@ -131,7 +131,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We gratefully make use of Dipy's automatic response function estimation. We convert Dmipy's acquisition scheme to a Dipy gradient table using `gtab_mipy2dipy`."
+    "We gratefully make use of Dipy's automatic response function estimation. We convert Dmipy's acquisition scheme to a Dipy gradient table using `gtab_dmipy2dipy`."
    ]
   },
   {
@@ -151,9 +151,9 @@
     }
    ],
    "source": [
-    "from dmipy.core.acquisition_scheme import gtab_mipy2dipy\n",
+    "from dmipy.core.acquisition_scheme import gtab_dmipy2dipy\n",
     "from dipy.reconst.csdeconv import auto_response\n",
-    "gtab = gtab_mipy2dipy(scheme_hcp)\n",
+    "gtab = gtab_dmipy2dipy(scheme_hcp)\n",
     "response, ratio = auto_response(gtab, data_hcp, roi_radius=10, fa_thr=0.7)\n",
     "lambdas = response[0]\n",
     "lambdas"

--- a/examples/tutorial_parameter_cascading_and_simulating_nd_datasets.ipynb
+++ b/examples/tutorial_parameter_cascading_and_simulating_nd_datasets.ipynb
@@ -279,10 +279,10 @@
    ],
    "source": [
     "from dipy.reconst import dti\n",
-    "from dmipy.core.acquisition_scheme import gtab_mipy2dipy\n",
+    "from dmipy.core.acquisition_scheme import gtab_dmipy2dipy\n",
     "\n",
     "# convert dmipy acquisition scheme to dipy gradient table\n",
-    "gtab = gtab_mipy2dipy(acq_scheme)\n",
+    "gtab = gtab_dmipy2dipy(acq_scheme)\n",
     "# initialize the dti model\n",
     "tenmod = dti.TensorModel(gtab)\n",
     "# fit the dti model\n",

--- a/examples/tutorial_setting_up_acquisition_scheme.ipynb
+++ b/examples/tutorial_setting_up_acquisition_scheme.ipynb
@@ -157,9 +157,9 @@
    ],
    "source": [
     "from dipy.core.gradients import gradient_table\n",
-    "from dmipy.core.acquisition_scheme import gtab_dipy2mipy\n",
+    "from dmipy.core.acquisition_scheme import gtab_dipy2dmipy\n",
     "gtab_dipy = gradient_table(bvalues, gradient_directions, big_delta=Delta, small_delta=delta)\n",
-    "acq_scheme_mipy = gtab_dipy2mipy(gtab_dipy)\n",
+    "acq_scheme_mipy = gtab_dipy2dmipy(gtab_dipy)\n",
     "acq_scheme_mipy.print_acquisition_info"
    ]
   },

--- a/examples/tutorial_setting_up_acquisition_scheme.ipynb
+++ b/examples/tutorial_setting_up_acquisition_scheme.ipynb
@@ -32,10 +32,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# load the necessary modules\n",
@@ -122,6 +120,51 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Setting up a Dmipy acquisition scheme when delta and Delta are unknown\n",
+    "It is possible we are using clinical data where the delta and Delta parameters are unknown or hard to find out for the acquisition parameters.\n",
+    "\n",
+    "Dmipy allows you to set up an acquisition scheme using only the bvalues and gradient directions (so just omitting delta and Delta), which will still allow you to use most of Dmipy's models. If a model is used that actually needs this information, this will be made clear with an appropriate error message."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Acquisition scheme summary\n",
+      "\n",
+      "total number of measurements: 288\n",
+      "number of b0 measurements: 18\n",
+      "number of DWI shells: 3\n",
+      "\n",
+      "shell_index |# of DWIs |bvalue [s/mm^2] |gradient strength [mT/m] |delta [ms] |Delta[ms] |TE[ms]\n",
+      "0           |18        |0               |N/A                      |N/A        |N/A       |N/A  \n",
+      "1           |90        |1000            |N/A                      |N/A        |N/A       |N/A  \n",
+      "2           |90        |2000            |N/A                      |N/A        |N/A       |N/A  \n",
+      "3           |90        |3000            |N/A                      |N/A        |N/A       |N/A  \n"
+     ]
+    }
+   ],
+   "source": [
+    "acq_scheme = acquisition_scheme_from_bvalues(bvalues_SI, gradient_directions)\n",
+    "acq_scheme.print_acquisition_info"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that now the gradient strength cannot be calculated from the bvalues and delta/Delta are unknown, but this has no effect on how shells are separated."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Setting up a Dmipy acquisition scheme by converting a Dipy GradientTable"
    ]
   },
@@ -134,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -186,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -224,8 +267,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "acq_scheme_mipy.to_schemefile(join(acquisition_path, \"schemefile_hcp_wu_minn.scheme1\"))"
@@ -255,7 +300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- [x] renames old gtab_dipy2mipy and gtab_mipy2dipy to be dmipy instead of mipy.
- [x] gtab_dipy2dmipy accepts gtabs without delta/Delta, but with warning.
- [x] dipy2dmipy gtabs without small_delta and big_delta pass None for these values in the AcquisitionScheme, but this can only be done with acquisition_scheme_from_bvalues().
- [x] removed superfluous _rotational_scheme() function in acquisition_scheme.py
- [x] gtab_dmipy2dipy gives error for acquisition schemes with multiple delta/Delta.
    - [x] assert that this error comes.
- [x] prune_acquisition_scheme function must also pass arguments of the original acquisition scheme w.r.t. b0 threshold and shell_distance, otherwise the pruned scheme can still have the right measurements, but be wrongly setup because of the default values.
    - [x] test for pruned function
- [x] acquisition_scheme accepts empty delta/Delta and the values are displayed in summary as N/A just as TE can be.
- [x] upon calling model.fit(scheme, data) AND simulate_data() the scheme is checked if it is compatible with the models, i.e., if the models need delta/Delta and it is not there, an appropriate error is given.
- [x] same for fitted models predict()
    - [x] add _required_acquisition_parameters to each compartment model
    - [x] add tests to check the raises when the wrong acquisition scheme is used
- [x] update acquisition scheme tutorial

closes #33 