### PR TITLE
Dmipy 0.2 framework refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Constrained spherical deconvolution (CSD) models are primarily used for Fiber Or
 ## How to contribute to Dmipy
 Dmipy's design is completely modular and can easily be extended with new models, distributions or optimizers. To contribute, view our [contribution guidelines](https://github.com/AthenaEPI/dmipy/blob/master/contribution_guidelines.rst).
 ## How to cite Dmipy
-- **Temporarily Reference**: Rutger Fick, Demian Wassermann and Rachid Deriche *Mipy: An Open-Source Framework to improve reproducibility in Brain Microstructure Imaging*, OHBM (2018) Singapore.
+- **Temporarily Reference**: Rutger Fick, Abib Alimi, Demian Wassermann and Rachid Deriche *Dmipy, a Diffusion Microstructure Imaging toolbox in Python to improve research reproducibility*, MICCAI (2018) Spain.
 - **Github Repository**: Rutger Fick, Rachid Deriche, & Demian Wassermann. (2018, March 3). *Dmipy: An Open-source Framework for Reproducible dMRI-Based Microstructure Research (Version 0.1)*. Zenodo. http://doi.org/10.5281/zenodo.1188268
 
 [Package Acknowledgements](https://github.com/AthenaEPI/dmipy/blob/master/Acknowledgements.md)


### PR DESCRIPTION
This PR contains major API upgrades and streamlining of the MC modeling and optimization pipeline.

- [ ] Updated biophysical model API
  - [ ] _parameter_scales is removed as all parameters will always be rescaled between 0 and 1 in the optimization based only on _parameter_bounds.

- [ ] Updated MC model API:
  - [x] introduction of dummy model where tortuosity can be defined. This will enable MIX to use e.g MC-SM models that use tortuosity;
  - [ ] MC, MC-SM and MC-SC models are wrappers for the same MC base model, but process the defined model parameters / settings for the base model to correspond with the desired functionality. This will allow us to simplify the API (and reduce copied code) in core.py.
  - [ ] model.fit will follow a similar API of scipy.optimize.minimize.
    - [ ] it is possible to give the optimizer name and optimizer parameters as keywords in model.fit()
    - [ ] Alternatively, there are separate functions to set the optimizer and its parameters, e.g. model.set_lbfgs_optimizer(params), after which model.fit(acquisition scheme, data) uses the set optimizer parameters.
  - [x] s0 responses is optional secondary input of MC models, and it NOT a property of CompartmentModels anymore.

- [ ] Updated optimizer API:
  - [ ] __init__() of optimizer class takes all optimizer options (e.g. regularizations, ftol, gtol);
  - [ ] inside any optimizer all parameters are always scaled between 0 and 1, are rescaled in the callback to generate the data from the MC-model;
  - [ ] depending on the optimizer, has voxel-wise fitting function inside the class instance, but leaves the freedom to implement contextual optimization strategies.
  - [ ] __call__() of optimizer class takes:
    - [ ] MC-model callback to generate the signal for given parameters;
    - [ ] data volume (ND-array x N_DWI),
    - [ ] parameter scaling parameters (ND-array x N_parameters x 2) for lower bound and scale, i.e. original param = scale * optimized_parameter + lower bound (SI-unit)
    - [ ] x0 volume (ND-array x N_parameters) with nan for non-x0-volume 
data input is defined per volume instead of per voxel.

- [ ] Refactored distributed models
  - [ ] distributed models towards core
  - [ ] separation between spherical-distributed models and parameter-distributed models.
  - [ ] separation of spatial and spherical distributions in distributions folder

- [ ] Updated examples for new API
- [ ] copyright notice on top of source files
- [ ] general cleaning