### PR TITLE
Adds catch for fitting data without b0 measurements.

### DIFF
--- a/dmipy/core/modeling_framework.py
+++ b/dmipy/core/modeling_framework.py
@@ -813,7 +813,7 @@ class MultiCompartmentModelProperties:
         Parameters
         ----------
         acquisition_scheme : DmipyAcquisitionScheme instance,
-            An acquisition scheme that has been instantiated using dMipy.
+            An acquisition scheme that has been instantiated using Dmipy.
         """
         for model in self.models:
             if model._model_type == 'TissueResponseModel':
@@ -834,6 +834,20 @@ class MultiCompartmentModelProperties:
                     msg = "Acquisition scheme of MC-model and tissue response "
                     msg += "model are not the same."
                     raise ValueError(msg)
+
+    def _check_acquisition_scheme_has_b0s(self, acquisition_scheme):
+        """
+        Checks if acquisition scheme has any b0-measurements. This for the
+        moment is a prerequisite for signal-attenuation-based model fitting.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using Dmipy.
+        """
+        if not np.any(acquisition_scheme.b0_mask):
+            raise ValueError('acquisition scheme must have b0-measurements '
+                             'for signal-attenuation-based model fitting.')
 
     def _construct_convolution_kernel(self, **kwargs):
         """
@@ -1039,6 +1053,7 @@ class MultiCompartmentModel(MultiCompartmentModelProperties):
         """
         self._check_tissue_model_acquisition_scheme(acquisition_scheme)
         self._check_model_params_with_acquisition_params(acquisition_scheme)
+        self._check_acquisition_scheme_has_b0s(acquisition_scheme)
 
         # estimate S0
         self.scheme = acquisition_scheme
@@ -1399,6 +1414,7 @@ class MultiCompartmentSphericalMeanModel(MultiCompartmentModelProperties):
         """
         self._check_tissue_model_acquisition_scheme(acquisition_scheme)
         self._check_model_params_with_acquisition_params(acquisition_scheme)
+        self._check_acquisition_scheme_has_b0s(acquisition_scheme)
 
         # estimate S0
         self.scheme = acquisition_scheme
@@ -1812,6 +1828,7 @@ class MultiCompartmentSphericalHarmonicsModel(MultiCompartmentModelProperties):
         """
         self._check_if_kernel_parameters_are_fixed()
         self._check_tissue_model_acquisition_scheme(acquisition_scheme)
+        self._check_acquisition_scheme_has_b0s(acquisition_scheme)
         self._check_model_params_with_acquisition_params(acquisition_scheme)
 
         self.voxel_varying_kernel = False

--- a/dmipy/core/tests/test_raises_multicompartment_input.py
+++ b/dmipy/core/tests/test_raises_multicompartment_input.py
@@ -1,9 +1,12 @@
 from dmipy.core import modeling_framework
+from dmipy.core.acquisition_scheme import (
+    acquisition_scheme_from_bvalues)
 from dmipy.signal_models import (
     cylinder_models, plane_models, gaussian_models)
 from numpy.testing import assert_raises
 from dmipy.data.saved_acquisition_schemes import (
     wu_minn_hcp_acquisition_scheme)
+import numpy as np
 
 
 def test_raise_combination_NRM_and_others():
@@ -64,3 +67,13 @@ def test_set_fixed_parameter_raises():
                   'C1Stick_1_mu', [1])
     assert_raises(ValueError, mod.set_fixed_parameter,
                   'blabla', [1])
+
+
+def test_fitting_without_b0_raises():
+    bvals = np.atleast_1d(1e9)
+    bvecs = np.atleast_2d([1., 0., 0.])
+    scheme = acquisition_scheme_from_bvalues(bvals, bvecs)
+    mc = modeling_framework.MultiCompartmentModel(
+        [gaussian_models.G1Ball()])
+    data = np.atleast_1d(1.)
+    assert_raises(ValueError, mc.fit, scheme, data)


### PR DESCRIPTION
Addresses avoidable obscure numpy error when scheme without b0 measurements is used to fit data in issue #45.