### PR TITLE
Includes generalized S0 tissue responses in signal simulation and fitting.

### DIFF
--- a/dmipy/signal_models/capped_cylinder_models.py
+++ b/dmipy/signal_models/capped_cylinder_models.py
@@ -109,7 +109,7 @@ class CC2CappedCylinderStejskalTannerApproximation(
             self._cylinder_model.perpendicular_attenuation(
                 q_perp[q_nonzero], diameter)
         )
-        return E_parallel * E_perpendicular
+        return self.S0 * self.S0 * E_parallel * E_perpendicular
 
 
 class CC3CappedCylinderCallaghanApproximation(
@@ -235,4 +235,4 @@ class CC3CappedCylinderCallaghanApproximation(
             self._cylinder_model.perpendicular_attenuation(
                 q_perp[q_nonzero], tau[q_nonzero], diameter)
         )
-        return E_parallel * E_perpendicular
+        return self.S0 * E_parallel * E_perpendicular

--- a/dmipy/signal_models/cylinder_models.py
+++ b/dmipy/signal_models/cylinder_models.py
@@ -89,7 +89,7 @@ class C1Stick(ModelProperties, AnisotropicSignalModelProperties):
         mu = kwargs.get('mu', self.mu)
         mu = utils.unitsphere2cart_1d(mu)
         E_stick = _attenuation_parallel_stick(bvals, lambda_par_, n, mu)
-        return E_stick
+        return self.S0 * E_stick
 
     def spherical_mean(self, acquisition_scheme, **kwargs):
         """
@@ -228,7 +228,7 @@ class C2CylinderStejskalTannerApproximation(
         E_perpendicular[q_nonzero] = self.perpendicular_attenuation(
             q_perp[q_nonzero], diameter
         )
-        return E_parallel * E_perpendicular
+        return self.S0 * E_parallel * E_perpendicular
 
 
 class C3CylinderCallaghanApproximation(
@@ -376,7 +376,7 @@ class C3CylinderCallaghanApproximation(
         E_perpendicular[q_nonzero] = self.perpendicular_attenuation(
             q_perp[q_nonzero], tau[q_nonzero], diameter
         )
-        return E_parallel * E_perpendicular
+        return self.S0 * E_parallel * E_perpendicular
 
 
 class C4CylinderGaussianPhaseApproximation(
@@ -494,7 +494,7 @@ class C4CylinderGaussianPhaseApproximation(
             E_perpendicular[mask] = self.perpendicular_attenuation(
                 g_perp[mask], delta_, Delta_, diameter
             )
-        return E_parallel * E_perpendicular
+        return self.S0 * E_parallel * E_perpendicular
 
 
 def _attenuation_parallel_stick(bvals, lambda_par, n, mu):

--- a/dmipy/signal_models/gaussian_models.py
+++ b/dmipy/signal_models/gaussian_models.py
@@ -75,7 +75,7 @@ class G1Ball(ModelProperties, IsotropicSignalModelProperties):
         bvals = acquisition_scheme.bvalues
         lambda_iso = kwargs.get('lambda_iso', self.lambda_iso)
         E_ball = np.exp(-bvals * lambda_iso)
-        return E_ball
+        return self.S0 * E_ball
 
 
 class G2Zeppelin(ModelProperties, AnisotropicSignalModelProperties):
@@ -152,7 +152,7 @@ class G2Zeppelin(ModelProperties, AnisotropicSignalModelProperties):
         mu = utils.unitsphere2cart_1d(mu)
         E_zeppelin = _attenuation_zeppelin(
             bvals, lambda_par, lambda_perp, n, mu)
-        return E_zeppelin
+        return self.S0 * E_zeppelin
 
     def spherical_mean(self, acquisition_scheme, **kwargs):
         """
@@ -298,7 +298,7 @@ class G3TemporalZeppelin(ModelProperties, AnisotropicSignalModelProperties):
             D_h = np.diag(np.r_[lambda_par, D_perp, D_perp])
             D = np.dot(np.dot(R, D_h), R.T)
             E_zeppelin[i] = np.exp(-bval_ * np.dot(n_, np.dot(n_, D)))
-        return E_zeppelin
+        return self.S0 * E_zeppelin
 
     def spherical_mean(self, acquisition_scheme, **kwargs):
         """

--- a/dmipy/signal_models/sphere_models.py
+++ b/dmipy/signal_models/sphere_models.py
@@ -50,7 +50,7 @@ class S1Dot(ModelProperties, IsotropicSignalModelProperties):
             signal attenuation
         '''
         E_dot = np.ones(acquisition_scheme.number_of_measurements)
-        return E_dot
+        return self.S0 * E_dot
 
 
 class S2SphereStejskalTannerApproximation(
@@ -123,7 +123,7 @@ class S2SphereStejskalTannerApproximation(
         q_nonzero = q > 0  # only q>0 attenuate
         E_sphere[q_nonzero] = self.sphere_attenuation(
             q[q_nonzero], diameter)
-        return E_sphere
+        return self.S0 * E_sphere
 
 
 class _S3SphereCallaghanApproximation(
@@ -224,7 +224,7 @@ class _S3SphereCallaghanApproximation(
         E_sphere[q_nonzero] = self.sphere_attenuation(
             q[q_nonzero], tau[q_nonzero], diameter
         )
-        return E_sphere
+        return self.S0 * E_sphere
 
 
 class S4SphereGaussianPhaseApproximation(
@@ -360,4 +360,4 @@ class S4SphereGaussianPhaseApproximation(
             E_sphere[mask] = self.sphere_attenuation(
                 g[mask], delta_, Delta_, diameter
             )
-        return E_sphere
+        return self.S0 * E_sphere

--- a/dmipy/signal_models/tissue_response_models.py
+++ b/dmipy/signal_models/tissue_response_models.py
@@ -140,7 +140,7 @@ class AnisotropicTissueResponseModel(
                 rh_mat = real_sym_rh_basis(shell_sh, theta, phi)
                 E[shell_mask] = np.dot(
                     rh_mat, rh_coef[native_shell_index, :shell_sh // 2 + 1])
-        return E
+        return self.S0 * E
 
     def rotational_harmonics_representation(
             self, acquisition_scheme=None, **kwargs):
@@ -160,7 +160,7 @@ class AnisotropicTissueResponseModel(
         rh_array : array, shape(Nshells, N_rh_coef),
             Rotational harmonics coefficients for each shell.
         """
-        return self._rotational_harmonics_representation[1:]
+        return self.S0 * self._rotational_harmonics_representation[1:]
 
     def spherical_mean(self, acquisition_scheme=None, **kwargs):
         """
@@ -179,7 +179,7 @@ class AnisotropicTissueResponseModel(
         E_mean : float,
             spherical mean of the Zeppelin model for every acquisition shell.
         """
-        return self._spherical_mean
+        return self.S0 * self._spherical_mean
 
     def tissue_response(self, **kwargs):
         # Returns the tissue response including S0 intensity.
@@ -274,7 +274,7 @@ class IsotropicTissueResponseModel(
             native_shell_index = np.where(shell_overlap)[0][0]
             shell_mask = acquisition_scheme.shell_indices == shell_index
             E[shell_mask] = self._spherical_mean[native_shell_index]
-        return E
+        return self.S0 * E
 
     def rotational_harmonics_representation(
             self, acquisition_scheme=None, **kwargs):
@@ -292,7 +292,7 @@ class IsotropicTissueResponseModel(
         rh_array : array, shape(Nshells, N_rh_coef),
             Rotational harmonics coefficients for each shell.
         """
-        return self._rotational_harmonics_representation[1:]
+        return self.S0 * self._rotational_harmonics_representation[1:]
 
     def spherical_mean(self, acquisition_scheme=None, **kwargs):
         """
@@ -311,7 +311,7 @@ class IsotropicTissueResponseModel(
         E_mean : float,
             spherical mean of the Zeppelin model for every acquisition shell.
         """
-        return self._spherical_mean
+        return self.S0 * self._spherical_mean
 
     def tissue_response(self, **kwargs):
         # Returns the tissue response including S0 intensity.

--- a/dmipy/tissue_response/white_matter_response.py
+++ b/dmipy/tissue_response/white_matter_response.py
@@ -190,8 +190,8 @@ def white_matter_response_tournier13(
                 values[..., 0] * (1 - values[..., 1] / values[..., 0])) ** 2
         selected_indices_old = selected_indices
         selected_indices = np.argsort(ratio)[:N_candidate_voxels]
-        percentage_overlap = len(np.intersect1d(
-            selected_indices, selected_indices_old)) / N_candidate_voxels * 100
+        percentage_overlap = 100. * float(len(np.intersect1d(
+            selected_indices, selected_indices_old))) / N_candidate_voxels
         print('{:.1f} percent candidate voxel overlap.'.format(
             percentage_overlap))
         if percentage_overlap == 100.:


### PR DESCRIPTION
- [x] closes #22 
- [x] Fixes printing of tournier12 tissue response overlap percentage
- [ ] add tests

Changes MC-modeling signal generation from a simple __call__ to be specifically mc.signal() and mc.signal_attenuation()....

signal() should only be calleable if the S0 for the compartments was set....

optimization on the signal should be 2-steps:
- first step fits parameters on signal attenuation (unity constraint)
- second step should do volume fraction correction, taking parameters p as the truth, and do convex optimization as f* = argmin |Af - E|, where A is has been multipltied by tissue specific S0_i/S0. 