### PR TITLE
Bugfix setting allow_pickle=True for np.load() for numpy version >1.16.1

### DIFF
--- a/dmipy/distributions/distributions.py
+++ b/dmipy/distributions/distributions.py
@@ -35,8 +35,8 @@ SPHERE_CARTESIAN = np.loadtxt(
 )
 SPHERE_SPHERICAL = utils.cart2sphere(SPHERE_CARTESIAN)
 log_bingham_normalization_splinefit = np.load(
-    join(DATA_PATH,
-         "bingham_normalization_splinefit.npz"), encoding='bytes')['arr_0']
+    join(DATA_PATH, "bingham_normalization_splinefit.npz"),
+    encoding='bytes', allow_pickle=True)['arr_0']
 
 inverse_sh_matrix_kernel = {
     sh_order: np.linalg.pinv(real_sym_sh_mrtrix(


### PR DESCRIPTION
Probably fixes issue #58 for newer numpy versions, which set `allow_pickle=False` by default for security reasons. Before it was True by default, which is what prompted the error now.