### PR TITLE
Small bug fix in signal_decay_metric

### DIFF
--- a/dmipy/tissue_response/three_tissue_response.py
+++ b/dmipy/tissue_response/three_tissue_response.py
@@ -217,7 +217,7 @@ def signal_decay_metric(acquisition_scheme, data):
         mean_dwi_shells[..., i] = np.mean(data[..., shell_mask], axis=-1)
 
     SDM = np.zeros(data_shape)
-    mask = mean_b0 > 0
+    mask = np.min(np.concatenate((np.expand_dims(mean_b0, axis=-1), mean_dwi_shells), axis=-1), axis=-1)>0    
     ratio = np.log(mean_b0[mask, None] / mean_dwi_shells[mask])
     SDM[mask] = np.mean(ratio, axis=-1)
     return SDM

--- a/dmipy/tissue_response/three_tissue_response.py
+++ b/dmipy/tissue_response/three_tissue_response.py
@@ -217,7 +217,8 @@ def signal_decay_metric(acquisition_scheme, data):
         mean_dwi_shells[..., i] = np.mean(data[..., shell_mask], axis=-1)
 
     SDM = np.zeros(data_shape)
-    mask = np.min(np.concatenate((np.expand_dims(mean_b0, axis=-1), mean_dwi_shells), axis=-1), axis=-1)>0    
+    mask = np.min(np.concatenate((np.expand_dims(mean_b0, axis=-1), 
+                                  mean_dwi_shells), axis=-1), axis=-1)>0    
     ratio = np.log(mean_b0[mask, None] / mean_dwi_shells[mask])
     SDM[mask] = np.mean(ratio, axis=-1)
     return SDM


### PR DESCRIPTION
The mask in the signal decay metric is calculated as all voxels with b0>0. However, it can happen that the diffusion weighted signal is zero while b0>0. In line 221 (ratio = np.log(mean_b0[mask, None] / mean_dwi_shells[mask])), this leads to a ratio of infinity and the program breaks a few lines further down. This behavior can for example be seen in subject 118730 of the HCP dataset.

A possible solution would be the proposed mask, which also takes non-zero b-value voxels into account.