### PR TITLE
FIX: change use of print for py3 compatibility

### DIFF
--- a/dmipy/utils/spherical_mean.py
+++ b/dmipy/utils/spherical_mean.py
@@ -84,5 +84,5 @@ def estimate_spherical_mean_shell(
     # Integral of Y00 spherical harmonic is 2 * np.sqrt(np.pi)
     # Multiplication results in normalization of 1 / (2 * np.sqrt(np.pi))
     E_mean = E_sh_coef[0] / (2 * np.sqrt(np.pi))
-    print 'emean', E_mean
+    print('emean', E_mean)
     return E_mean


### PR DESCRIPTION
In dmipy.utils.spherical_mean `print` is used as a statement, which is
not compatible with python 3.

This PR fixes it and now `print` is used as a function.

This PR solves issue #69 .