### PR TITLE
FIX: pass scheme to call of MultiCompartmentSphericalHarmonicsModel

### DIFF
--- a/dmipy/core/modeling_framework.py
+++ b/dmipy/core/modeling_framework.py
@@ -863,7 +863,7 @@ class MultiCompartmentModelProperties:
             raise ValueError('acquisition scheme must have b0-measurements '
                              'for signal-attenuation-based model fitting.')
 
-    def _construct_convolution_kernel(self, acquisition_scheme, **kwargs):
+    def _construct_convolution_kernel(self, acquisition_scheme=None, **kwargs):
         """
         Helper function that constructs the convolution kernel for the given
         multi-compartment model and the initial condition x0_vector.
@@ -893,6 +893,9 @@ class MultiCompartmentModelProperties:
             coefficients to the DWI signal values.
         """
         parameters_dict = self.add_linked_parameters_to_parameters(kwargs)
+
+        if acquisition_scheme is None:
+            acquisition_scheme = self.scheme
 
         if self.volume_fractions_fixed:
             if len(self.models) > 1:


### PR DESCRIPTION
This commit changes the behaviour of the `simulate_signal` and the `__call__` function of instances of the
MultiCompartmentSphericalHarmonicsModel class by changing the
`_construct_convolution_kernel` method.

Before this commit, the acquisition scheme employed by the method was
the one contained in the `self.scheme` attribute. After applying this
commit, the employed acquisition scheme is the one passed as the keyword
argument `acquisition_scheme=` to the method. If it is not passed, the
function will use the one contained in `self.scheme` for backward
compatibility.