### PR TITLE
BUGFIX: median otsu parameters to latest dipy version.

### DIFF
--- a/dmipy/tissue_response/three_tissue_response.py
+++ b/dmipy/tissue_response/three_tissue_response.py
@@ -82,7 +82,7 @@ def three_tissue_response_dhollander16(
     SDM = signal_decay_metric(acquisition_scheme, data)
 
     # Make Mask
-    b0_mask, mask = median_otsu(data, 2, 1)
+    b0_mask, mask = median_otsu(data, median_radius=2, numpass=1)
     gtab = gtab_dmipy2dipy(acquisition_scheme)
     tenmod = dti.TensorModel(gtab)
     tenfit = tenmod.fit(b0_mask)

--- a/dmipy/version.py
+++ b/dmipy/version.py
@@ -4,7 +4,7 @@ from os.path import join as pjoin
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 1
 _version_minor = 0
-_version_micro = 2  # use '' for first of series, number for 1 and above
+_version_micro = 3  # use '' for first of series, number for 1 and above
 _version_extra = ''
 # _version_extra = ''  # Uncomment this for full releases
 


### PR DESCRIPTION
closes #76 and bumps micro version of dmipy package.