### PR TITLE
FEAT: add skeleton for amico implementation

### DIFF
--- a/dmipy/core/fitted_modeling_framework.py
+++ b/dmipy/core/fitted_modeling_framework.py
@@ -897,3 +897,629 @@ class FittedMultiCompartmentSphericalHarmonicsModel:
         mse = np.mean((data_ - y_hat) ** 2, axis=-1)
         mse[~self.mask] = 0
         return mse
+
+class FittedMultiCompartmentAMICOModel:
+    """
+    The FittedMultiCompartmentModel instance contains information about the
+    original MultiCompartmentModel, the estimated S0 values, the fitting mask
+    and the fitted model parameters.
+
+    Parameters
+    ----------
+    model : MultiCompartmentAMICOModel instance,
+        A dmipy MultiCompartmentAMICOModel.
+    S0 : array of size (Ndata,) or (N_data, N_DWIs),
+        Array containing the estimated S0 values of the data. If data is 4D,
+        then S0 is 3D if there is only one TE, and the same 4D size of the data
+        if there are multiple TEs.
+    mask : array of size (N_data,),
+        boolean mask of voxels that were fitted.
+    fitted_parameters_vector : array of size (N_data, Nparameters),
+        fitted model parameters array.
+    """
+
+    def __init__(self, model, S0, mask, fitted_parameters_vector,
+                 fitted_multi_tissue_fractions_vector=None):
+        self.model = model
+        self.S0 = S0
+        self.mask = mask
+        self.fitted_parameters_vector = fitted_parameters_vector
+        self.fitted_multi_tissue_fractions_vector = (
+            fitted_multi_tissue_fractions_vector)
+
+    @property
+    def fitted_distribution(self):
+        """Returns the distribution of each parameter."""
+        # TODO: we have to find a way to return the distribution of each
+        #  parameter obtained from the optimization
+        raise NotImplementedError
+
+    @property
+    def fitted_parameters(self):
+        "Returns the fitted parameters as a dictionary."
+        # TODO: this could also rely on the fitted_distribution property
+        return NotImplementedError
+
+    @property
+    def fitted_multi_tissue_fractions(self):
+        "Returns the fitted multi tissue fractions as a dictionary."
+        return self._return_fitted_multi_tissue_fractions()
+
+    @property
+    def fitted_multi_tissue_fractions_normalized(self):
+        "Returns the normalized fitted multi tissue fractions as a dictionary"
+        return self._return_fitted_multi_tissue_fractions(normalized=True)
+
+    def _return_fitted_multi_tissue_fractions(self, normalized=False):
+        """
+        Returns the multi-tissue estimated volume fractions.
+
+        Parameters
+        ----------
+        normalized: boolean,
+            whether or not to normalize returned multi-tissue volume fractions.
+            NOTE: This does not mean the unity constraint was enforced during
+            the estimation of the fractions - it is just a normalization after
+            the fact.
+
+        Returns
+        -------
+        mt_partial_volumes: dict,
+            contains the multi-tissue volume fractions by name.
+            NOTE: if the MC-model only consisted of 1 model, then the name will
+            be 'partial_volume_0', but will not have a counterpart in
+            self.fitted_parameters.
+        """
+        mt_fract_vec = self.fitted_multi_tissue_fractions_vector.copy()
+        if normalized:
+            mt_fract_sum = np.sum(mt_fract_vec, axis=-1)
+            mt_fract_mask = mt_fract_sum > 0
+            mt_fract_vec[mt_fract_mask] = (
+                mt_fract_vec[mt_fract_mask] /
+                mt_fract_sum[mt_fract_mask][..., None])
+        if self.model.N_models > 1:
+            fract_names = self.model.partial_volume_names
+        else:
+            fract_names = ['partial_volume_0']
+        mt_partial_volumes = {}
+        for i, partial_volume_name in enumerate(fract_names):
+            mt_partial_volumes[partial_volume_name] = mt_fract_vec[..., i]
+        return mt_partial_volumes
+
+    @property
+    def fitted_and_linked_parameters(self):
+        "Returns the fitted and linked parameters as a dictionary."
+        fitted_parameters = self.model.parameter_vector_to_parameters(
+            self.fitted_parameters_vector)
+        return self.model.add_linked_parameters_to_parameters(
+            fitted_parameters)
+
+    def fod(self, vertices, visual_odi_lower_bound=0.):
+        """
+        Returns the Fiber Orientation Distribution if it is available.
+
+        Parameters
+        ----------
+        vertices : array of size (Nvertices, 3),
+            Array of cartesian unit vectors at which to sample the FOD.
+        visual_odi_lower_bound : float,
+            gives a lower bound to the Orientation Distribution Index (ODI) of
+            FODs of Watson and Bingham distributions. This can be useful to
+            visualize FOD fields where some FODs are extremely sharp.
+
+        Returns
+        -------
+        fods : array of size (Ndata, Nvertices),
+            the FODs of the fitted model, scaled by volume fraction.
+        """
+        if not self.model.fod_available:
+            msg = ('FODs not available for current model.')
+            raise ValueError(msg)
+        dataset_shape = self.fitted_parameters_vector.shape[:-1]
+        N_samples = len(vertices)
+        fods = np.zeros(np.r_[dataset_shape, N_samples])
+        mask_pos = np.where(self.mask)
+        for pos in zip(*mask_pos):
+            parameters = self.model.parameter_vector_to_parameters(
+                self.fitted_parameters_vector[pos])
+            if visual_odi_lower_bound > 0:
+                param_keys = parameters.keys()
+                for key in param_keys:
+                    if key[-3:] == 'odi':
+                        parameters[key] = np.clip(parameters[key],
+                                                  visual_odi_lower_bound, 1)
+            fods[pos] = self.model(vertices, quantity='FOD', **parameters)
+        return fods
+
+    def fod_sh(self, sh_order=8, basis_type=None):
+        """
+        Returns the spherical harmonics coefficients of the Fiber Orientation
+        Distribution (FOD) if it is available. Uses are 724 spherical
+        tessellation to do the spherical harmonics transform.
+
+        Parameters
+        ----------
+        sh_order : integer,
+            the maximum spherical harmonics order of the coefficient expansion.
+        basis_type : string,
+            type of spherical harmonics basis to use for the expansion, see
+            sh_to_sf_matrix for more info.
+
+        Returns
+        -------
+        fods_sh : array of size (Ndata, Ncoefficients),
+            spherical harmonics coefficients of the FODs, scaled by volume
+            fraction.
+        """
+        if not self.model.fod_available:
+            msg = ('FODs not available for current model.')
+            raise ValueError(msg)
+        sphere = get_sphere(name='repulsion724')
+        vertices = sphere.vertices
+        _, inv_sh_matrix = sh_to_sf_matrix(
+            sphere, sh_order, basis_type=basis_type, return_inv=True)
+        fods_sf = self.fod(vertices)
+
+        dataset_shape = self.fitted_parameters_vector.shape[:-1]
+        number_coef_used = int((sh_order + 2) * (sh_order + 1) // 2)
+        fods_sh = np.zeros(np.r_[dataset_shape, number_coef_used])
+        mask_pos = np.where(self.mask)
+        for pos in zip(*mask_pos):
+            fods_sh[pos] = np.dot(inv_sh_matrix.T, fods_sf[pos])
+        return fods_sh
+
+    def peaks_spherical(self):
+        "Returns the peak angles of the model."
+        mu_params = []
+        for name, card in self.model.parameter_cardinality.items():
+            if name[-2:] == 'mu' and card == 2:
+                mu_params.append(self.fitted_parameters[name])
+        if len(mu_params) == 0:
+            msg = ('peaks not available for current model.')
+            raise ValueError(msg)
+        if len(mu_params) == 1:
+            return np.expand_dims(mu_params[0], axis=-2)
+        return np.concatenate([mu[..., None] for mu in mu_params], axis=-1)
+
+    def peaks_cartesian(self):
+        "Returns the cartesian peak unit vectors of the model."
+        peaks_spherical = self.peaks_spherical()
+        peaks_cartesian = unitsphere2cart_Nd(peaks_spherical)
+        return peaks_cartesian
+
+    def predict(self, acquisition_scheme=None, S0=None, mask=None):
+        """
+        simulates the dMRI signal of the fitted MultiCompartmentModel for the
+        estimated model parameters. If no acquisition_scheme is given, then
+        the same acquisition_scheme that was used for the fitting is used. If
+        no S0 is given then it is assumed to be the estimated one. If no mask
+        is given then all voxels are assumed to have been fitted.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using dMipy.
+        S0 : None or float,
+            Signal intensity without diffusion sensitization. If None, uses
+            estimated SO from fitting process. If float, uses that value.
+        mask : (N-1)-dimensional integer/boolean array of size (N_x, N_y, ...),
+            mask of voxels to simulate data at.
+
+        Returns
+        -------
+        predicted_signal : array of size (Ndata, N_DWIS),
+            predicted DWIs for the given model parameters and acquisition
+            scheme.
+        """
+        if acquisition_scheme is None:
+            acquisition_scheme = self.model.scheme
+        self.model._check_model_params_with_acquisition_params(
+            acquisition_scheme)
+
+        dataset_shape = self.fitted_parameters_vector.shape[:-1]
+        if S0 is None:
+            S0 = self.S0
+        elif isinstance(S0, float):
+            S0 = np.ones(dataset_shape) * S0
+        if mask is None:
+            mask = self.mask
+
+        N_samples = len(acquisition_scheme.bvalues)
+
+        predicted_signal = np.zeros(np.r_[dataset_shape, N_samples])
+        mask_pos = np.where(mask)
+        for pos in zip(*mask_pos):
+            parameters = self.model.parameter_vector_to_parameters(
+                self.fitted_parameters_vector[pos])
+            predicted_signal[pos] = self.model(
+                acquisition_scheme, **parameters) * S0[pos]
+        return predicted_signal
+
+    def R2_coefficient_of_determination(self, data):
+        "Calculates the R-squared of the model fit."
+        data_ = data / self.S0[..., None]
+
+        y_hat = self.predict(S0=1.)
+        y_bar = np.mean(data_, axis=-1)
+        SStot = np.sum((data_ - y_bar[..., None]) ** 2, axis=-1)
+        SSres = np.sum((data_ - y_hat) ** 2, axis=-1)
+        R2 = 1 - SSres / SStot
+        R2[~self.mask] = 0
+        return R2
+
+    def mean_squared_error(self, data):
+        "Calculates the mean squared error of the model fit."
+        if self.model.scheme.TE is None:
+            data_ = data / self.S0[..., None]
+        else:
+            data_ = data / self.S0
+
+        y_hat = self.predict(S0=1.)
+        mse = np.mean((data_ - y_hat) ** 2, axis=-1)
+        mse[~self.mask] = 0
+        return mse
+
+class FittedMultiCompartmentAMICOSphericalMeanModel:
+    """
+    The FittedMultiCompartmentAMICOModel instance contains information about the
+    original MultiCompartmentModel, the estimated S0 values, the fitting mask
+    and the fitted model parameters.
+
+    Parameters
+    ----------
+    model : MultiCompartmentModel instance,
+        A dmipy MultiCompartmentModel.
+    S0 : array of size (Ndata,) or (N_data, N_DWIs),
+        Array containing the estimated S0 values of the data. If data is 4D,
+        then S0 is 3D if there is only one TE, and the same 4D size of the data
+        if there are multiple TEs.
+    mask : array of size (N_data,),
+        boolean mask of voxels that were fitted.
+    fitted_parameters_vector : array of size (N_data, Nparameters),
+        fitted model parameters array.
+    """
+
+    def __init__(self, model, S0, mask, fitted_parameters_vector,
+                 fitted_multi_tissue_fractions_vector=None):
+        self.model = model
+        self.S0 = S0
+        self.mask = mask
+        self.fitted_parameters_vector = fitted_parameters_vector
+        self.fitted_multi_tissue_fractions_vector = (
+            fitted_multi_tissue_fractions_vector)
+
+    @property
+    def fitted_distribution(self):
+        """Returns the distribution of each parameter."""
+        # TODO: we have to find a way to return the distribution of each
+        #  parameter obtained from the optimization
+        raise NotImplementedError
+
+    @property
+    def fitted_parameters(self):
+        "Returns the fitted parameters as a dictionary."
+        # TODO: this could also rely on the fitted_distribution property
+        return NotImplementedError
+
+    @property
+    def fitted_and_linked_parameters(self):
+        "Returns the fitted and linked parameters as a dictionary."
+        fitted_parameters = self.model.parameter_vector_to_parameters(
+            self.fitted_parameters_vector)
+        return self.model.add_linked_parameters_to_parameters(
+            fitted_parameters)
+
+    @property
+    def fitted_multi_tissue_fractions(self):
+        "Returns the fitted multi tissue fractions as a dictionary."
+        return self._return_fitted_multi_tissue_fractions()
+
+    @property
+    def fitted_multi_tissue_fractions_normalized(self):
+        "Returns the normalized fitted multi tissue fractions as a dictionary"
+        return self._return_fitted_multi_tissue_fractions(normalized=True)
+
+    def _return_fitted_multi_tissue_fractions(self, normalized=False):
+        """
+        Returns the multi-tissue estimated volume fractions.
+
+        Parameters
+        ----------
+        normalized: boolean,
+            whether or not to normalize returned multi-tissue volume fractions.
+            NOTE: This does not mean the unity constraint was enforced during
+            the estimation of the fractions - it is just a normalization after
+            the fact.
+
+        Returns
+        -------
+        mt_partial_volumes: dict,
+            contains the multi-tissue volume fractions by name.
+            NOTE: if the MC-model only consisted of 1 model, then the name will
+            be 'partial_volume_0', but will not have a counterpart in
+            self.fitted_parameters.
+        """
+        mt_fract_vec = self.fitted_multi_tissue_fractions_vector.copy()
+        if normalized:
+            mt_fract_sum = np.sum(mt_fract_vec, axis=-1)
+            mt_fract_mask = mt_fract_sum > 0
+            mt_fract_vec[mt_fract_mask] = (
+                mt_fract_vec[mt_fract_mask] /
+                mt_fract_sum[mt_fract_mask][..., None])
+        if self.model.N_models > 1:
+            fract_names = self.model.partial_volume_names
+        else:
+            fract_names = ['partial_volume_0']
+        mt_partial_volumes = {}
+        for i, partial_volume_name in enumerate(fract_names):
+            mt_partial_volumes[partial_volume_name] = mt_fract_vec[..., i]
+        return mt_partial_volumes
+
+    def predict(self, acquisition_scheme=None, S0=None, mask=None):
+        """
+        simulates the dMRI signal of the fitted MultiCompartmentModel for the
+        estimated model parameters. If no acquisition_scheme is given, then
+        the same acquisition_scheme that was used for the fitting is used. If
+        no S0 is given then it is assumed to be the estimated one. If no mask
+        is given then all voxels are assumed to have been fitted.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using dMipy.
+        S0 : None or float,
+            Signal intensity without diffusion sensitization. If None, uses
+            estimated SO from fitting process. If float, uses that value.
+        mask : (N-1)-dimensional integer/boolean array of size (N_x, N_y, ...),
+            mask of voxels to simulate data at.
+
+        Returns
+        -------
+        predicted_signal : array of size (Ndata, N_DWIS),
+            predicted DWIs for the given model parameters and acquisition
+            scheme.
+        """
+        if acquisition_scheme is None:
+            acquisition_scheme = self.model.scheme
+        self.model._check_model_params_with_acquisition_params(
+            acquisition_scheme)
+
+        dataset_shape = self.fitted_parameters_vector.shape[:-1]
+        if S0 is None:
+            S0 = self.S0
+        elif isinstance(S0, float):
+            S0 = np.ones(dataset_shape) * S0
+        if mask is None:
+            mask = self.mask
+
+        N_samples = len(acquisition_scheme.shell_bvalues)
+
+        predicted_signal = np.zeros(np.r_[dataset_shape, N_samples])
+        mask_pos = np.where(mask)
+        for pos in zip(*mask_pos):
+            parameters = self.model.parameter_vector_to_parameters(
+                self.fitted_parameters_vector[pos])
+            predicted_signal[pos] = self.model(
+                acquisition_scheme, **parameters) * S0[pos]
+        return predicted_signal
+
+    def R2_coefficient_of_determination(self, data):
+        "Calculates the R-squared of the model fit."
+        Nshells = len(self.model.scheme.shell_bvalues)
+        data_ = np.zeros(np.r_[data.shape[:-1], Nshells])
+        for pos in zip(*np.where(self.mask)):
+            data_[pos] = estimate_spherical_mean_multi_shell(
+                data[pos] / self.S0[pos], self.model.scheme)
+
+        y_hat = self.predict(S0=1.)
+        y_bar = np.mean(data_, axis=-1)
+        SStot = np.sum((data_ - y_bar[..., None]) ** 2, axis=-1)
+        SSres = np.sum((data_ - y_hat) ** 2, axis=-1)
+        R2 = 1 - SSres / SStot
+        R2[~self.mask] = 0
+        return R2
+
+    def mean_squared_error(self, data):
+        "Calculates the mean squared error of the model fit."
+        Nshells = len(self.model.scheme.shell_bvalues)
+        data_ = np.zeros(np.r_[data.shape[:-1], Nshells])
+        for pos in zip(*np.where(self.mask)):
+            data_[pos] = estimate_spherical_mean_multi_shell(
+                data[pos] / self.S0[pos], self.model.scheme)
+
+        y_hat = self.predict(S0=1.)
+        mse = np.mean((data_ - y_hat) ** 2, axis=-1)
+        mse[~self.mask] = 0
+        return mse
+
+    def return_parametric_fod_model(
+            self, distribution='watson', Ncompartments=1):
+        """
+        Retuns parametric FOD model using the rotational harmonics of the
+        fitted spherical mean model as the convolution kernel. It can be called
+        with any implemented parametric distribution (Watson/Bingham) and for
+        any number of compartments.
+
+        Internally, the input models to the spherical mean model are given to
+        a spherically distributed model where the parameter links are replayed
+        such that the distributed model has the same parameter constraints as
+        the spherical mean model. This distributed model now represents one
+        compartment of "bundle". This bundle representation is copied
+        Ncompartment times and given as input to a MultiCompartmentModel, where
+        now the non-linear are all linked such that each bundle has the same
+        convolution kernel. Finally, the FittedSphericalMeanModel parameters
+        are given as fixed parameters for the kernel (the kernel will not be
+        fitted while the FOD's distribution parameters are being optimized).
+
+        The function returns a MultiCompartmentModel instance that can be
+        interacted with as usual to fit dMRI data.
+
+        Parameters
+        ----------
+        distribution: string,
+            Choice of parametric spherical distribution.
+            Can be 'watson', or 'bingham'.
+        Ncompartments: integer,
+            Number of bundles that will be fitted. Must be larger than zero.
+
+        Returns
+        -------
+        mc_bundles_model: Dmipy MultiCompartmentModel instance,
+            MultiCompartmentModel instance that can be used to estimate
+            parametric FODs using the fitted spherical mean model as a kernel.
+        """
+        from .modeling_framework import MultiCompartmentModel
+        from ..distributions import distribute_models
+
+        if not isinstance(Ncompartments, int) or Ncompartments < 1:
+            msg = 'Ncompartments must be integer larger or equal to one.'
+            raise ValueError(msg)
+
+        if distribution == 'watson':
+            bundle = distribute_models.SD1WatsonDistributed(
+                self.model.models)
+            basename = 'SD1WatsonDistributed_'
+        elif distribution == 'bingham':
+            bundle = distribute_models.SD2BinghamDistributed(
+                self.model.models)
+            basename = 'SD2BinghamDistributed_'
+        else:
+            msg = '{} is not a valid distribution choice'.format(
+                distribute_models)
+            raise ValueError(msg)
+
+        for link in self.model.parameter_links:
+            param_to_delete = self.model._inverted_parameter_map[link[0],
+                                                                 link[1]]
+            if link[2] is T1_tortuosity:
+                bundle.parameter_links.append(
+                    [link[0], link[1], link[2], link[3][:-1]])
+            elif link[2] is fractional_parameter:
+                new_parameter_name = param_to_delete + '_fraction'
+                bundle.parameter_ranges.update({new_parameter_name: [0., 1.]})
+                bundle.parameter_scales.update({new_parameter_name: 1.})
+                bundle.parameter_cardinality.update({new_parameter_name: 1})
+                bundle.parameter_types.update({new_parameter_name: 'normal'})
+
+                bundle._parameter_map.update(
+                    {new_parameter_name: (None, 'fraction')})
+                bundle._inverted_parameter_map.update(
+                    {(None, 'fraction'): new_parameter_name})
+
+                # add parmeter link to fractional parameter
+                param_larger_than = self.model._inverted_parameter_map[
+                    link[3][1][0], link[3][1][1]]
+
+                model, name = bundle._parameter_map[param_to_delete]
+                bundle.parameter_links.append(
+                    [model, name, fractional_parameter, [
+                        bundle._parameter_map[new_parameter_name],
+                        bundle._parameter_map[param_larger_than]]])
+            else:
+                bundle.parameter_links.append(link)
+            del bundle.parameter_ranges[param_to_delete]
+            del bundle.parameter_cardinality[param_to_delete]
+            del bundle.parameter_scales[param_to_delete]
+            del bundle.parameter_types[param_to_delete]
+
+        bundles = [bundle.copy() for i in range(Ncompartments)]
+        mc_bundles_model = MultiCompartmentModel(bundles)
+        parameter_pairs = []
+        for smt_par_name in self.model.parameter_names:
+            parameters = []
+            parameters.append(smt_par_name)
+            for mc_par_name in mc_bundles_model.parameter_names:
+                if (mc_par_name.startswith(basename) and
+                        mc_par_name.endswith(smt_par_name)):
+                    parameters.append(mc_par_name)
+            if len(parameters) > 1:
+                parameter_pairs.append(parameters)
+
+        for parameters in parameter_pairs:
+            for i in range(2, Ncompartments + 1):
+                mc_bundles_model.set_equal_parameter(parameters[1],
+                                                     parameters[i])
+
+        for parameters in parameter_pairs:
+            smt_parameter_name = parameters[0]
+            mc_parameter_name = parameters[1]
+            mc_bundles_model.set_fixed_parameter(
+                mc_parameter_name,
+                self.fitted_parameters[smt_parameter_name])
+        return mc_bundles_model
+
+    def return_spherical_harmonics_fod_model(self, sh_order=8):
+        """
+        Retuns spherical harmonics FOD model using the rotational harmonics of
+        the fitted spherical mean model as the convolution kernel.
+
+        Internally, the input models to the spherical mean model are given to
+        a MultiCompartmentSphericalHarmonicsModel where the parameter links are
+        replayed such that the new model has the same parameter constraints as
+        the spherical mean model. The FittedSphericalMeanModel parameters
+        are given as fixed parameters for the kernel (the kernel will not be
+        fitted while the FOD's coefficients are being optimized).
+
+        The function returns a MultiCompartmentSphericalHarmonicsModel instance
+        that can be interacted with as usual to fit dMRI data.
+
+        Parameters
+        ----------
+        sh_order: even, positive integer,
+            Spherical harmonics order of the FODs.
+
+        Returns
+        -------
+        mc_bundles_model: Dmipy MultiCompartmentModel instance,
+            MultiCompartmentModel instance that can be used to estimate
+            parametric FODs using the fitted spherical mean model as a kernel.
+        """
+        from .modeling_framework import MultiCompartmentSphericalHarmonicsModel
+
+        if sh_order < 0 or sh_order % 2 != 0:
+            msg = 'sh_order must be an even, positive integer.'
+            raise ValueError(msg)
+
+        sh_model = MultiCompartmentSphericalHarmonicsModel(
+            self.model.models, sh_order=sh_order)
+
+        for link in self.model.parameter_links:
+            param_to_delete = self.model._inverted_parameter_map[link[0],
+                                                                 link[1]]
+            if link[2] is T1_tortuosity:
+                sh_model.parameter_links.append(
+                    [link[0], link[1], link[2], link[3][:-1]])
+            elif link[2] is fractional_parameter:
+                new_parameter_name = param_to_delete + '_fraction'
+                sh_model.parameter_ranges.update(
+                    {new_parameter_name: [0., 1.]})
+                sh_model.parameter_scales.update({new_parameter_name: 1.})
+                sh_model.parameter_cardinality.update({new_parameter_name: 1})
+                sh_model.parameter_types.update({new_parameter_name: 'normal'})
+
+                sh_model._parameter_map.update(
+                    {new_parameter_name: (None, 'fraction')})
+                sh_model._inverted_parameter_map.update(
+                    {(None, 'fraction'): new_parameter_name})
+
+                # add parmeter link to fractional parameter
+                param_larger_than = self.model._inverted_parameter_map[
+                    link[3][1][0], link[3][1][1]]
+
+                model, name = sh_model._parameter_map[param_to_delete]
+                sh_model.parameter_links.append(
+                    [model, name, fractional_parameter, [
+                        sh_model._parameter_map[new_parameter_name],
+                        sh_model._parameter_map[param_larger_than]]])
+            else:
+                sh_model.parameter_links.append(link)
+            del sh_model.parameter_ranges[param_to_delete]
+            del sh_model.parameter_cardinality[param_to_delete]
+            del sh_model.parameter_scales[param_to_delete]
+            del sh_model.parameter_types[param_to_delete]
+            del sh_model.parameter_optimization_flags[param_to_delete]
+
+        for smt_par_name in self.model.parameter_names:
+            sh_model.set_fixed_parameter(
+                smt_par_name, self.fitted_parameters[smt_par_name])
+        return sh_model

--- a/dmipy/core/modeling_framework.py
+++ b/dmipy/core/modeling_framework.py
@@ -18,7 +18,9 @@ from ..utils.utils import (
 from .fitted_modeling_framework import (
     FittedMultiCompartmentModel,
     FittedMultiCompartmentSphericalMeanModel,
-    FittedMultiCompartmentSphericalHarmonicsModel)
+    FittedMultiCompartmentSphericalHarmonicsModel,
+    FittedMultiCompartmentAMICOModel,
+    FittedMultiCompartmentAMICOSphericalMeanModel)
 from ..optimizers.brute2fine import (
     GlobalBruteOptimizer, Brute2FineOptimizer)
 from ..optimizers_fod.csd_tournier import CsdTournierOptimizer
@@ -2189,6 +2191,735 @@ class MultiCompartmentSphericalHarmonicsModel(MultiCompartmentModelProperties):
                 'sh_coeff']
             E = np.dot(A, sh_coeff)
         return E
+
+
+class MultiCompartmentAMICOModel(MultiCompartmentModelProperties):
+    def __init__(self, models, S0_tissue_responses=None, parameter_links=None):
+        self.models = models
+        self.N_models = len(models)
+        if S0_tissue_responses is not None:
+            if len(S0_tissue_responses) != self.N_models:
+                msg = 'Number of S0_tissue responses {} must be same as '\
+                      'number of input models {}.'
+                raise ValueError(
+                    msg.format(len(S0_tissue_responses), self.N_models))
+        self.S0_tissue_responses = S0_tissue_responses
+        self.parameter_links = parameter_links
+        if parameter_links is None:
+            self.parameter_links = []
+
+        self._prepare_parameters()
+        self._prepare_partial_volumes()
+        self._prepare_parameter_links()
+        self._prepare_model_properties()
+        self._check_for_double_model_class_instances()
+        self._prepare_parameters_to_optimize()
+        self._check_for_NMR_and_other_models()
+        self.x0_parameters = {}
+        self._forward_model_matrix = None
+
+        if not have_numba:
+            msg = "We highly recommend installing numba for faster function "
+            msg += "execution and model fitting."
+            print(msg)
+        if not have_pathos:
+            msg = "We highly recommend installing pathos to take advantage of "
+            msg += "multicore processing."
+            print(msg)
+
+    def _check_for_NMR_and_other_models(self):
+        model_types = [model._model_type for model in self.models]
+        if "NMRModel" in model_types:
+            if len(np.unique(model_types)) > 1:
+                msg = "Cannot combine 1D-NMR and other 3D model types together"
+                msg += " into a MultiCompartmentAMICOModel."
+                raise ValueError(msg)
+
+    def _create_forward_model_matrix(self):
+        # TODO: implement the function that creates the forward model matrix
+        raise NotImplementedError
+
+    @property
+    def forward_model(self):
+        if self._forward_model_matrix is None:
+            self._create_forward_model_matrix()
+        return self._forward_model_matrix
+
+    def fit(self, acquisition_scheme, data,
+            mask=None,
+            solver=None, # TODO: define the solver
+            Ns=5,
+            maxiter=300,
+            N_sphere_samples=30,
+            use_parallel_processing=have_pathos,
+            number_of_processors=None):
+        """ The main data fitting function of a MultiCompartmentModel.
+
+        This function can fit it to an N-dimensional dMRI data set, and returns
+        a FittedMultiCompartmentModel instance that contains the fitted
+        parameters and other useful functions to study the results.
+
+        No initial guess needs to be given to fit a model, but a partial or
+        complete initial guess can be given if the user wants to have a
+        solution that is a local minimum close to that guess. The
+        parameter_initial_guess input can be created using
+        parameter_initial_guess_to_parameter_vector().
+
+        A mask can also be given to exclude voxels from fitting (e.g. voxels
+        that are outside the brain). If no mask is given then all voxels are
+        included.
+
+        An optimization approach can be chosen as either 'brute2fine' or 'mix'.
+        - Choosing brute2fine will first use a brute-force optimization to find
+          an initial guess for parameters without one, and will then refine the
+          result using gradient-descent-based optimization.
+
+          Note that given no initial guess will make brute2fine precompute an
+          global parameter grid that will be re-used for all voxels, which in
+          many cases is much faster than giving voxel-varying initial condition
+          that requires a grid to be estimated per voxel.
+
+        - Choosing mix will use the recent MIX algorithm based on separation of
+          linear and non-linear parameters. MIX first uses a stochastic
+          algorithm to find the non-linear parameters (non-volume fractions),
+          then estimates the volume fractions while fixing the estimates of the
+          non-linear parameters, and then finally refines the solution using
+          a gradient-descent-based algorithm.
+
+        The fitting process can be readily parallelized using the optional
+        "pathos" package. If it is installed then it will automatically use it,
+        but it can be turned off by setting use_parallel_processing=False. The
+        algorithm will automatically use all cores in the machine, unless
+        otherwise specified in number_of_processors.
+
+        Data with multiple TE are normalized in separate segments using the
+        b0-values according that TE.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using dMipy.
+        data : N-dimensional array of size (N_x, N_y, ..., N_dwis),
+            The measured DWI signal attenuation array of either a single voxel
+            or an N-dimensional dataset.
+        mask : (N-1)-dimensional integer/boolean array of size (N_x, N_y, ...),
+            Optional mask of voxels to be included in the optimization.
+        solver : string,
+            TODO: ?
+        Ns : integer,
+            for brute optimization, decised how many steps are sampled for
+            every parameter. TODO: ?
+        maxiter : integer,
+            for MIX optimization, how many iterations are allowed. TODO: ?
+        N_sphere_samples : integer,
+            for brute optimization, how many spherical orientations are sampled
+            for 'mu'. TODO: ?
+        use_parallel_processing : bool,
+            whether or not to use parallel processing using pathos.
+        number_of_processors : integer,
+            number of processors to use for parallel processing. Defaults to
+            the number of processors in the computer according to cpu_count().
+
+        Returns
+        -------
+        FittedMultiCompartmentAMICOModel: class instance that contains fitted
+        parameters. Can be used to recover parameters themselves or other useful
+        functions.
+        """
+        self._check_tissue_model_acquisition_scheme(acquisition_scheme)
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
+        self._check_acquisition_scheme_has_b0s(acquisition_scheme)
+        self._check_if_volume_fractions_are_fixed()
+
+        # estimate S0
+        self.scheme = acquisition_scheme
+        data_ = np.atleast_2d(data)
+        if self.scheme.TE is None or len(np.unique(self.scheme.TE)) == 1:
+            S0 = np.mean(data_[..., self.scheme.b0_mask], axis=-1)
+        else:  # if multiple TE are in the data
+            S0 = np.ones_like(data_)
+            for TE_ in self.scheme.shell_TE:
+                TE_mask = self.scheme.TE == TE_
+                TE_b0_mask = np.all([self.scheme.b0_mask, TE_mask], axis=0)
+                S0[..., TE_mask] = np.mean(
+                    data_[..., TE_b0_mask], axis=-1)[..., None]
+
+        if mask is None:
+            mask = data_[..., 0] > 0
+        else:
+            mask = np.all([mask, data_[..., 0] > 0], axis=0)
+        mask_pos = np.where(mask)
+
+        N_parameters = len(self.bounds_for_optimization)
+        N_voxels = np.sum(mask)
+
+        # make starting parameters and data the same size
+        x0_ = self.parameter_initial_guess_to_parameter_vector(
+            **self.x0_parameters)
+        x0_ = homogenize_x0_to_data(
+            data_, x0_)
+        x0_bool = np.all(
+            np.isnan(x0_), axis=tuple(np.arange(x0_.ndim - 1)))
+        x0_[..., ~x0_bool] /= self.scales_for_optimization[~x0_bool]
+
+        if use_parallel_processing and not have_pathos:
+            msg = 'Cannot use parallel processing without pathos.'
+            raise ValueError(msg)
+        elif use_parallel_processing and have_pathos:
+            fitted_parameters_lin = [None] * N_voxels
+            if number_of_processors is None:
+                number_of_processors = cpu_count()
+            pool = pp.ProcessPool(number_of_processors)
+            print('Using parallel processing with {} workers.'.format(
+                number_of_processors))
+        else:
+            fitted_parameters_lin = np.empty(
+                np.r_[N_voxels, N_parameters], dtype=float)
+
+        # TODO: complete the setup of the optimization in model fitting
+        def fit_func(*args, **kwargs):
+            # This function will use the self.forward_model property
+            # TODO: implement the fit_func method for the model fitting
+            raise NotImplementedError
+        self.optimizer = fit_func
+
+        start = time()
+        for idx, pos in enumerate(zip(*mask_pos)):
+            voxel_E = data_[pos] / S0[pos]
+            voxel_x0_vector = x0_[pos]
+            # TODO: preprocess the x0 as required by the solver
+            fit_args = (voxel_E, voxel_x0_vector)
+
+            if use_parallel_processing:
+                fitted_parameters_lin[idx] = pool.apipe(fit_func, *fit_args)
+            else:
+                fitted_parameters_lin[idx] = fit_func(*fit_args)
+        if use_parallel_processing:
+            fitted_parameters_lin = np.array(
+                [p.get() for p in fitted_parameters_lin])
+            pool.close()
+            pool.join()
+            pool.clear()
+
+        fitting_time = time() - start
+        print('Fitting of {} voxels complete in {} seconds.'.format(
+            len(fitted_parameters_lin), fitting_time))
+        print('Average of {} seconds per voxel.'.format(
+            fitting_time / N_voxels))
+
+        fitted_mt_fractions = None
+        if self.S0_tissue_responses:
+            # TODO: rescale the signal fractions to get the volume fractions
+            mt_fractions = None
+            msg = 'Multi-tissue fitting of {} voxels complete in {} seconds.'
+            print(msg.format(len(mt_fractions), fitting_time))
+            fitted_mt_fractions = np.zeros(np.r_[mask.shape, self.N_models])
+            fitted_mt_fractions[mask_pos] = mt_fractions
+
+        fitted_parameters = np.zeros_like(x0_, dtype=float)
+        fitted_parameters[mask_pos] = (
+            fitted_parameters_lin * self.scales_for_optimization)
+
+        return FittedMultiCompartmentAMICOModel(
+            self, S0, mask, fitted_parameters, fitted_mt_fractions)
+
+    def simulate_signal(self, acquisition_scheme, parameters_array_or_dict):
+        """
+        Function to simulate diffusion data for a given acquisition_scheme
+        and model parameters for the MultiCompartmentModel.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using dMipy
+        model_parameters_array : 1D array of size (N_parameters) or
+            N-dimensional array the same size as the data.
+            The model parameters of the MultiCompartmentModel model.
+
+        Returns
+        -------
+        E_simulated: 1D array of size (N_parameters) or N-dimensional
+            array the same size as x0.
+            The simulated signal of the microstructure model.
+        """
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
+
+        Ndata = acquisition_scheme.number_of_measurements
+        if isinstance(parameters_array_or_dict, np.ndarray):
+            x0 = parameters_array_or_dict
+        elif isinstance(parameters_array_or_dict, dict):
+            x0 = self.parameters_to_parameter_vector(
+                **parameters_array_or_dict)
+
+        x0_at_least_2d = np.atleast_2d(x0)
+        x0_2d = x0_at_least_2d.reshape(-1, x0_at_least_2d.shape[-1])
+        E_2d = np.empty(np.r_[x0_2d.shape[:-1], Ndata])
+        for i, x0_ in enumerate(x0_2d):
+            parameters = self.parameter_vector_to_parameters(x0_)
+            E_2d[i] = self(acquisition_scheme, **parameters)
+        E_simulated = E_2d.reshape(
+            np.r_[x0_at_least_2d.shape[:-1], Ndata])
+
+        if x0.ndim == 1:
+            return np.squeeze(E_simulated)
+        else:
+            return E_simulated
+
+    def __call__(self, acquisition_scheme_or_vertices,
+                 quantity="signal", **kwargs):
+        """
+        The MultiCompartmentModel function call for to generate signal
+        attenuation for a given acquisition scheme and model parameters.
+
+        First, the linked parameters are added to the optimized parameters.
+
+        Then, every model in the MultiCompartmentModel is called with the right
+        parameters to recover the part of the signal attenuation of that model.
+        The resulting values are multiplied with the volume fractions and
+        finally the combined signal attenuation is returned.
+
+        Aside from the signal, the function call can also return the Fiber
+        Orientation Distributions (FODs) when a dispersed model is used, and
+        can also return the stochastic cost function for the MIX algorithm.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using dMipy.
+        quantity : string
+            can be 'signal', 'FOD' or 'stochastic cost function' depending on
+            the need of the model.
+        kwargs: keyword arguments to the model parameter values,
+            Is internally given as **parameter_dictionary.
+        """
+        if quantity == "signal" or quantity == "FOD":
+            values = 0
+        elif quantity == "stochastic cost function":
+            values = np.empty((
+                acquisition_scheme_or_vertices.number_of_measurements,
+                len(self.models)
+            ))
+            counter = 0
+
+        kwargs = self.add_linked_parameters_to_parameters(
+            kwargs
+        )
+        if len(self.models) > 1:
+            partial_volumes = [
+                kwargs[p] for p in self.partial_volume_names
+            ]
+        else:
+            partial_volumes = [1.]
+
+        for model_name, model, partial_volume in zip(
+            self.model_names, self.models, partial_volumes
+        ):
+            parameters = {}
+            for parameter in model.parameter_ranges:
+                parameter_name = self._inverted_parameter_map[
+                    (model, parameter)
+                ]
+                parameters[parameter] = kwargs.get(
+                    # , self.parameter_defaults.get(parameter_name)
+                    parameter_name
+                )
+
+            if quantity == "signal":
+                values = (
+                    values +
+                    partial_volume * model(
+                        acquisition_scheme_or_vertices, **parameters)
+                )
+            elif quantity == "FOD":
+                try:
+                    values = (
+                        values +
+                        partial_volume * model.fod(
+                            acquisition_scheme_or_vertices, **parameters)
+                    )
+                except AttributeError:
+                    continue
+            elif quantity == "stochastic cost function":
+                values[:, counter] = model(acquisition_scheme_or_vertices,
+                                           **parameters)
+                counter += 1
+        return values
+
+class MultiCompartmentAMICOSphericalMeanModel(MultiCompartmentModelProperties):
+    r'''
+    The MultiCompartmentAMICOSphericalMeanModel class allows to combine any
+    number of CompartmentModels and DistributedModels into one combined model
+    that can be used to fit and simulate dMRI data.
+
+    Parameters
+    ----------
+    models : list of N CompartmentModel instances,
+        the models to combine into the MultiCompartmentModel.
+    parameter_links : list of iterables (model, parameter name, link function,
+        argument list),
+        deprecated, for testing only.
+    '''
+
+    def __init__(self, models, S0_tissue_responses=None, parameter_links=None):
+        self.models = models
+        self.N_models = len(models)
+        if S0_tissue_responses is not None:
+            if len(S0_tissue_responses) != self.N_models:
+                msg = 'Number of S0_tissue responses {} must be same as '\
+                      'number of input models {}.'
+                raise ValueError(
+                    msg.format(len(S0_tissue_responses), self.N_models))
+        self.S0_tissue_responses = S0_tissue_responses
+        self.parameter_links = parameter_links
+        if parameter_links is None:
+            self.parameter_links = []
+
+        self._check_for_NMR_models()
+        self._prepare_parameters()
+        self._delete_orientation_parameters()
+        self._prepare_partial_volumes()
+        self._prepare_parameter_links()
+        self._prepare_model_properties()
+        self._check_for_double_model_class_instances()
+        self._prepare_parameters_to_optimize()
+        self.x0_parameters = {}
+        self._forward_model_matrix = None
+
+
+        if not have_numba:
+            msg = "We highly recommend installing numba for faster function "
+            msg += "execution and model fitting."
+            print(msg)
+        if not have_pathos:
+            msg = "We highly recommend installing pathos to take advantage of "
+            msg += "multicore processing."
+            print(msg)
+
+    def _check_for_NMR_models(self):
+        for model in self.models:
+            if model._model_type == 'NMRModel':
+                msg = "Cannot estimate spherical mean of 1D-NMR models."
+                raise ValueError(msg)
+
+    def _delete_orientation_parameters(self):
+        """
+        Deletes orientation parameters from input models 'mu' since they're not
+        needed in spherical mean models.
+        """
+        "Removes orientation parameters from input models."
+        for model in self.models:
+            for param_name, param_type in model.parameter_types.items():
+                if param_type == 'orientation':
+                    appended_param_name = self._inverted_parameter_map[
+                        model, param_name]
+                    del self.parameter_ranges[appended_param_name]
+                    del self.parameter_scales[appended_param_name]
+                    del self.parameter_cardinality[appended_param_name]
+                    del self.parameter_types[appended_param_name]
+
+    def fit(self, acquisition_scheme, data,
+            mask=None,
+            solver=None, # TODO: define the solver
+            Ns=5,
+            maxiter=300,
+            N_sphere_samples=30,
+            use_parallel_processing=have_pathos,
+            number_of_processors=None):
+        """ The main data fitting function of a MultiCompartmentModel.
+
+        This function can fit it to an N-dimensional dMRI data set, and returns
+        a FittedMultiCompartmentModel instance that contains the fitted
+        parameters and other useful functions to study the results.
+
+        No initial guess needs to be given to fit a model, but a partial or
+        complete initial guess can be given if the user wants to have a
+        solution that is a local minimum close to that guess. The
+        parameter_initial_guess input can be created using
+        parameter_initial_guess_to_parameter_vector().
+
+        A mask can also be given to exclude voxels from fitting (e.g. voxels
+        that are outside the brain). If no mask is given then all voxels are
+        included.
+
+        An optimization approach can be chosen as either 'brute2fine' or 'mix'.
+        - Choosing brute2fine will first use a brute-force optimization to find
+          an initial guess for parameters without one, and will then refine the
+          result using gradient-descent-based optimization.
+
+          Note that given no initial guess will make brute2fine precompute an
+          global parameter grid that will be re-used for all voxels, which in
+          many cases is much faster than giving voxel-varying initial condition
+          that requires a grid to be estimated per voxel.
+
+        - Choosing mix will use the recent MIX algorithm based on separation of
+          linear and non-linear parameters. MIX first uses a stochastic
+          algorithm to find the non-linear parameters (non-volume fractions),
+          then estimates the volume fractions while fixing the estimates of the
+          non-linear parameters, and then finally refines the solution using
+          a gradient-descent-based algorithm.
+
+        The fitting process can be readily parallelized using the optional
+        "pathos" package. If it is installed then it will automatically use it,
+        but it can be turned off by setting use_parallel_processing=False. The
+        algorithm will automatically use all cores in the machine, unless
+        otherwise specified in number_of_processors.
+
+        Data with multiple TE are normalized in separate segments using the
+        b0-values according that TE.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using dMipy.
+        data : N-dimensional array of size (N_x, N_y, ..., N_dwis),
+            The measured DWI signal attenuation array of either a single voxel
+            or an N-dimensional dataset.
+        mask : (N-1)-dimensional integer/boolean array of size (N_x, N_y, ...),
+            Optional mask of voxels to be included in the optimization.
+        solver : string,
+            Selection of optimization algorithm.
+            - 'brute2fine' to use brute-force optimization.
+            - 'mix' to use Microstructure Imaging of Crossing (MIX)
+              optimization.
+        Ns : integer,
+            for brute optimization, decised how many steps are sampled for
+            every parameter.
+        maxiter : integer,
+            for MIX optimization, how many iterations are allowed.
+        N_sphere_samples : integer,
+            for brute optimization, how many spherical orientations are sampled
+            for 'mu'.
+        use_parallel_processing : bool,
+            whether or not to use parallel processing using pathos.
+        number_of_processors : integer,
+            number of processors to use for parallel processing. Defaults to
+            the number of processors in the computer according to cpu_count().
+
+        Returns
+        -------
+        FittedCompartmentModel: class instance that contains fitted parameters,
+            Can be used to recover parameters themselves or other useful
+            functions.
+        """
+        self._check_tissue_model_acquisition_scheme(acquisition_scheme)
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
+        self._check_acquisition_scheme_has_b0s(acquisition_scheme)
+        self._check_if_volume_fractions_are_fixed()
+
+        # estimate S0
+        self.scheme = acquisition_scheme
+        data_ = np.atleast_2d(data)
+        if self.scheme.TE is None or len(np.unique(self.scheme.TE)) == 1:
+            S0 = np.mean(data_[..., self.scheme.b0_mask], axis=-1)
+        else:  # if multiple TE are in the data
+            S0 = np.ones(np.r_[data_.shape[:-1],
+                               len(acquisition_scheme.shell_TE)])
+            for TE_ in self.scheme.shell_TE:
+                TE_mask = self.scheme.shell_TE == TE_
+                TE_mask_shell = self.scheme.TE == TE_
+                TE_b0_mask = np.all([self.scheme.b0_mask, TE_mask_shell],
+                                    axis=0)
+                S0[..., TE_mask] = np.mean(
+                    data_[..., TE_b0_mask], axis=-1)[..., None]
+
+        if mask is None:
+            mask = data_[..., 0] > 0
+        else:
+            mask = np.all([mask, data_[..., 0] > 0], axis=0)
+        mask_pos = np.where(mask)
+
+        N_parameters = len(self.bounds_for_optimization)
+        N_voxels = np.sum(mask)
+
+        # make starting parameters and data the same size
+        x0_ = self.parameter_initial_guess_to_parameter_vector(
+            **self.x0_parameters)
+        x0_ = homogenize_x0_to_data(
+            data_, x0_)
+        x0_bool = np.all(
+            np.isnan(x0_), axis=tuple(np.arange(x0_.ndim - 1)))
+        x0_[..., ~x0_bool] /= self.scales_for_optimization[~x0_bool]
+
+        if use_parallel_processing and not have_pathos:
+            msg = 'Cannot use parallel processing without pathos.'
+            raise ValueError(msg)
+        elif use_parallel_processing and have_pathos:
+            fitted_parameters_lin = [None] * N_voxels
+            if number_of_processors is None:
+                number_of_processors = cpu_count()
+            pool = pp.ProcessPool(number_of_processors)
+            print('Using parallel processing with {} workers.'.format(
+                number_of_processors))
+        else:
+            fitted_parameters_lin = np.empty(
+                np.r_[N_voxels, N_parameters], dtype=float)
+
+        # estimate the spherical mean of the data.
+        data_to_fit = np.zeros(np.r_[data_.shape[:-1], self.scheme.N_shells])
+        for pos in zip(*mask_pos):
+            data_to_fit[pos] = estimate_spherical_mean_multi_shell(
+                data_[pos], self.scheme)
+
+        # TODO: complete the setup of the optimization in model fitting
+        def fit_func(*args, **kwargs):
+            # This function will use the self.forward_model property
+            # TODO: implement the fit_func method for the model fitting
+            raise NotImplementedError
+        self.optimizer = fit_func
+
+        start = time()
+        for idx, pos in enumerate(zip(*mask_pos)):
+            voxel_E = data_to_fit[pos] / S0[pos]
+            voxel_x0_vector = x0_[pos]
+            # TODO: preprocess the x0 as required by the solver
+            fit_args = (voxel_E, voxel_x0_vector)
+
+            if use_parallel_processing:
+                fitted_parameters_lin[idx] = pool.apipe(fit_func, *fit_args)
+            else:
+                fitted_parameters_lin[idx] = fit_func(*fit_args)
+        if use_parallel_processing:
+            fitted_parameters_lin = np.array(
+                [p.get() for p in fitted_parameters_lin])
+            pool.close()
+            pool.join()
+            pool.clear()
+
+        fitting_time = time() - start
+        print('Fitting of {} voxels complete in {} seconds.'.format(
+            len(fitted_parameters_lin), fitting_time))
+        print('Average of {} seconds per voxel.'.format(
+            fitting_time / N_voxels))
+
+        fitted_mt_fractions = None
+        if self.S0_tissue_responses:
+            # TODO: rescale the signal fractions to get the volume fractions
+            mt_fractions = None
+            msg = 'Multi-tissue fitting of {} voxels complete in {} seconds.'
+            print(msg.format(len(mt_fractions), fitting_time))
+            fitted_mt_fractions = np.zeros(np.r_[mask.shape, self.N_models])
+            fitted_mt_fractions[mask_pos] = mt_fractions
+
+        fitted_parameters = np.zeros_like(x0_, dtype=float)
+        fitted_parameters[mask_pos] = (
+            fitted_parameters_lin * self.scales_for_optimization)
+
+        return FittedMultiCompartmentAMICOSphericalMeanModel(
+            self, S0, mask, fitted_parameters, fitted_mt_fractions)
+
+    def simulate_signal(self, acquisition_scheme, parameters_array_or_dict):
+        """
+        Function to simulate diffusion data for a given acquisition_scheme
+        and model parameters for the MultiCompartmentModel.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using dMipy
+        model_parameters_array : 1D array of size (N_parameters) or
+            N-dimensional array the same size as the data.
+            The model parameters of the MultiCompartmentModel model.
+
+        Returns
+        -------
+        E_simulated: 1D array of size (N_parameters) or N-dimensional
+            array the same size as x0.
+            The simulated signal of the microstructure model.
+        """
+        self._check_model_params_with_acquisition_params(acquisition_scheme)
+
+        Ndata = acquisition_scheme.shell_indices.max() + 1
+        if isinstance(parameters_array_or_dict, np.ndarray):
+            x0 = parameters_array_or_dict
+        elif isinstance(parameters_array_or_dict, dict):
+            x0 = self.parameters_to_parameter_vector(
+                **parameters_array_or_dict)
+
+        x0_at_least_2d = np.atleast_2d(x0)
+        x0_2d = x0_at_least_2d.reshape(-1, x0_at_least_2d.shape[-1])
+        E_2d = np.empty(np.r_[x0_2d.shape[:-1], Ndata])
+        for i, x0_ in enumerate(x0_2d):
+            parameters = self.parameter_vector_to_parameters(x0_)
+            E_2d[i] = self(acquisition_scheme, **parameters)
+        E_simulated = E_2d.reshape(
+            np.r_[x0_at_least_2d.shape[:-1], Ndata])
+
+        if x0.ndim == 1:
+            return np.squeeze(E_simulated)
+        else:
+            return E_simulated
+
+    def __call__(self, acquisition_scheme_or_vertices,
+                 quantity="signal", **kwargs):
+        """
+        The MultiCompartmentModel function call for to generate signal
+        attenuation for a given acquisition scheme and model parameters.
+
+        First, the linked parameters are added to the optimized parameters.
+
+        Then, every model in the MultiCompartmentModel is called with the right
+        parameters to recover the part of the signal attenuation of that model.
+        The resulting values are multiplied with the volume fractions and
+        finally the combined signal attenuation is returned.
+
+        Aside from the signal, the function call can also return the Fiber
+        Orientation Distributions (FODs) when a dispersed model is used, and
+        can also return the stochastic cost function for the MIX algorithm.
+
+        Parameters
+        ----------
+        acquisition_scheme : DmipyAcquisitionScheme instance,
+            An acquisition scheme that has been instantiated using dMipy.
+        quantity : string
+            can be 'signal', 'FOD' or 'stochastic cost function' depending on
+            the need of the model.
+        kwargs: keyword arguments to the model parameter values,
+            Is internally given as **parameter_dictionary.
+        """
+        if quantity == "signal":
+            values = 0
+        elif quantity == "stochastic cost function":
+            values = np.empty((
+                len(acquisition_scheme_or_vertices.shell_bvalues),
+                len(self.models)
+            ))
+            counter = 0
+
+        kwargs = self.add_linked_parameters_to_parameters(
+            kwargs
+        )
+        if len(self.models) > 1:
+            partial_volumes = [
+                kwargs[p] for p in self.partial_volume_names
+            ]
+        else:
+            partial_volumes = [1.]
+
+        for model_name, model, partial_volume in zip(
+            self.model_names, self.models, partial_volumes
+        ):
+            parameters = {}
+            for parameter in model.parameter_ranges:
+                parameter_name = self._inverted_parameter_map[
+                    (model, parameter)
+                ]
+                parameters[parameter] = kwargs.get(
+                    # , self.parameter_defaults.get(parameter_name)
+                    parameter_name
+                )
+
+            if quantity == "signal":
+                values = (
+                    values +
+                    partial_volume * model.spherical_mean(
+                        acquisition_scheme_or_vertices, **parameters)
+                )
+            elif quantity == "stochastic cost function":
+                values[:, counter] = model.spherical_mean(
+                    acquisition_scheme_or_vertices,
+                    **parameters)
+                counter += 1
+        return values
 
 
 def homogenize_x0_to_data(data, x0):

--- a/dmipy/core/tests/test_amico_models.py
+++ b/dmipy/core/tests/test_amico_models.py
@@ -1,0 +1,99 @@
+from dmipy.distributions import distribute_models
+from dmipy.signal_models import cylinder_models, gaussian_models
+from dmipy.core import modeling_framework
+from dmipy.data.saved_acquisition_schemes import (
+    wu_minn_hcp_acquisition_scheme)
+import numpy as np
+from numpy.testing import assert_, assert_raises
+
+scheme = wu_minn_hcp_acquisition_scheme()
+
+
+def one_compartment_amico_model():
+    """
+    Provides a simple Stick AMICO-like model.
+
+    This function builds an AMICO model with a single compartment given by a
+    stick convolved with a watson distribution.
+
+    All the parameters are set randomly.
+
+    Returns:
+        tuple of length 2 with
+         * MultiCompartmentAMICOModel instance
+         * sample data simulated on the hcp acquisition scheme
+    """
+    stick = cylinder_models.C1Stick()
+    watsonstick = distribute_models.SD1WatsonDistributed(
+        [stick])
+    params = {}
+    for parameter, card, in watsonstick.parameter_cardinality.items():
+        params[parameter] = (np.random.rand(card) *
+                             watsonstick.parameter_scales[parameter])
+
+    model = modeling_framework.MultiCompartmentAMICOModel([watsonstick])
+    data = np.atleast_2d(watsonstick(scheme, **params))
+    return model, data
+
+
+def two_compartment_amico_model():
+    """
+    Provides a simple Stick-and-Ball AMICO-like model.
+
+    This function builds an AMICO model with two compartments given by a
+    stick convolved with a watson distribution and a ball.
+
+    All the parameters are set randomly.
+
+    Returns:
+        tuple of length 2 with
+         * MultiCompartmentAMICOModel instance
+         * sample data simulated on the hcp acquisition scheme
+    """
+    stick = cylinder_models.C1Stick()
+    ball = gaussian_models.G1Ball()
+    watsonstick = distribute_models.SD1WatsonDistributed(
+        [stick])
+    model = modeling_framework.MultiCompartmentAMICOModel([watsonstick, ball])
+
+    params = {}
+    for parameter, card, in model.parameter_cardinality.items():
+        params[parameter] = (np.random.rand(card) *
+                             model.parameter_scales[parameter])
+
+    for key, value in params.items():
+        model.set_fixed_parameter(key, value)
+
+    data = np.atleast_2d(model(scheme, **params))
+    return model, data
+
+
+def test_forward_model():
+    # TODO: test that the observation matrix is defined as expected
+    pass
+
+
+def test_nnls():
+    # TODO: test the non-regularized version of the inverse problem
+    pass
+
+
+def test_l2_regularization():
+    # TODO: test the effect of L2 regularization
+    pass
+
+
+def test_l1_regularization():
+    # TODO: test the effect of L1 regularization
+    pass
+
+
+def test_l1_and_l2_regularization():
+    # TODO: test the effect of using both L1 and L2 regularization
+    pass
+
+
+def test_fitted_amico_model_properties():
+    # TODO: check that the FittedMultiCompartmentAMICOModel class has the
+    #  expected properties
+    pass

--- a/dmipy/core/tests/test_amico_spherical_mean_models.py
+++ b/dmipy/core/tests/test_amico_spherical_mean_models.py
@@ -1,0 +1,100 @@
+from dmipy.distributions import distribute_models
+from dmipy.signal_models import cylinder_models, gaussian_models
+from dmipy.core import modeling_framework
+from dmipy.data.saved_acquisition_schemes import (
+    wu_minn_hcp_acquisition_scheme)
+import numpy as np
+from numpy.testing import assert_, assert_raises
+
+scheme = wu_minn_hcp_acquisition_scheme()
+
+
+def one_compartment_amico_model():
+    """
+    Provides a simple Stick AMICO-like model.
+
+    This function builds an AMICO model with a single compartment given by a
+    stick convolved with a watson distribution.
+
+    All the parameters are set randomly.
+
+    Returns:
+        tuple of length 2 with
+         * MultiCompartmentAMICOModel instance
+         * sample data simulated on the hcp acquisition scheme
+    """
+    stick = cylinder_models.C1Stick()
+    watsonstick = distribute_models.SD1WatsonDistributed(
+        [stick])
+    params = {}
+    for parameter, card, in watsonstick.parameter_cardinality.items():
+        params[parameter] = (np.random.rand(card) *
+                             watsonstick.parameter_scales[parameter])
+
+    model = modeling_framework.MultiCompartmentAMICOModel([watsonstick])
+    data = np.atleast_2d(watsonstick(scheme, **params))
+    return model, data
+
+
+def two_compartment_amico_model():
+    """
+    Provides a simple Stick-and-Ball AMICO-like model.
+
+    This function builds an AMICO model with two compartments given by a
+    stick convolved with a watson distribution and a ball.
+
+    All the parameters are set randomly.
+
+    Returns:
+        tuple of length 2 with
+         * MultiCompartmentAMICOModel instance
+         * sample data simulated on the hcp acquisition scheme
+    """
+    stick = cylinder_models.C1Stick()
+    ball = gaussian_models.G1Ball()
+    watsonstick = distribute_models.SD1WatsonDistributed(
+        [stick])
+    model = modeling_framework.MultiCompartmentAMICOSphericalMeanModel(
+        [watsonstick, ball])
+
+    params = {}
+    for parameter, card, in model.parameter_cardinality.items():
+        params[parameter] = (np.random.rand(card) *
+                             model.parameter_scales[parameter])
+
+    for key, value in params.items():
+        model.set_fixed_parameter(key, value)
+
+    data = np.atleast_2d(model(scheme, **params))
+    return model, data
+
+
+def test_forward_model():
+    # TODO: test that the observation matrix is defined as expected
+    pass
+
+
+def test_nnls():
+    # TODO: test the non-regularized version of the inverse problem
+    pass
+
+
+def test_l2_regularization():
+    # TODO: test the effect of L2 regularization
+    pass
+
+
+def test_l1_regularization():
+    # TODO: test the effect of L1 regularization
+    pass
+
+
+def test_l1_and_l2_regularization():
+    # TODO: test the effect of using both L1 and L2 regularization
+    pass
+
+
+def test_fitted_amico_model_properties():
+    # TODO: check that the FittedMultiCompartmentAMICOSphericalMeanModel class
+    #  has the expected properties
+    pass


### PR DESCRIPTION
With this PR we add the skeleton for the implementation of [AMICO](https://github.com/daducci/amico). Let's open the discussion.

### `dmipy.core.modeling_framework`
For the MultiCompartmentAMICOModel and the MultiCompartmentAMICOSphericalMeanModel we have to do the following:
* Implement `_create_forward_model_matrix`
* Choose a strategy for the solver to use. The difficulty stands in keeping the syntax consistent with the other models
* Update documentation of `fit` function
* Complete the setup of the optimization before model fitting in the `fit` function
* Implement the `fit_func` method in the `fit` function
* Preprocess the `x0` as required by the solver
* Implement the multi-tissue feature correctly

### `dmipy.core.fitted_modeling_framework`
* I added the `fitted_distribution` property to the FittedMultiCompartmentAMICOModel and FittedMultiCompartmentAMICOSphericalMeanModel classes. This is intended to return the distribution of each parameter obtained from the AMICO fitting.
* The `fitted_parameter` property could be built on top of the `fitted_distribution`.
