### PR TITLE
fix syntax error

### DIFF
--- a/dmipy/distributions/distribute_models.py
+++ b/dmipy/distributions/distribute_models.py
@@ -339,8 +339,8 @@ class DistributedModel:
             try:
                 self.parameter_ranges[param]
             except KeyError:
-                print("{} does not exist or has already been fixed.").format(
-                    param)
+                print("{} does not exist or has already been fixed.".format(
+                    param))
                 return None
         model, name = self._parameter_map[parameter_name_out]
         self.parameter_links.append([model, name, parameter_equality, [

--- a/dmipy/distributions/tests/test_distribute_models.py
+++ b/dmipy/distributions/tests/test_distribute_models.py
@@ -206,3 +206,18 @@ def test_C4_watson_gamma_equals_gamma_watson():
 
     assert_array_almost_equal(watsongammacyl(scheme, **params2),
                               gammawatsoncyl(scheme, **params1), 5)
+
+
+def test_set_equal_param():
+    cylinder = cylinder_models.C2CylinderStejskalTannerApproximation()
+    watsoncyl = distribute_models.SD1WatsonDistributed([cylinder])
+    p1 = 'C2CylinderStejskalTannerApproximation_1_lambda_par'
+    p2 = 'C2CylinderStejskalTannerApproximation_1_diameter'
+    watsoncyl.set_equal_parameter(p1, p2)
+
+    isnone = False
+    reset = watsoncyl.set_equal_parameter(p1, p2)
+    if reset is None:
+        isnone = True
+
+    assert_equal(isnone, True)


### PR DESCRIPTION
A wrong string formatting was generating an unexpected error. The problem is now fixed.

This PR solves issue #100 .