### PR TITLE
open readme only once in setup.py

### DIFF
--- a/dmipy/version.py
+++ b/dmipy/version.py
@@ -28,15 +28,12 @@ CLASSIFIERS = ["Development Status :: 3 - Alpha",
 # Description should be a one-liner:
 description = "dmipy: diffusion microstructure imaging in python"
 # Long description will go up on the pypi page
-with open('README.md', 'r') as f:
-    long_description = f.read()
 long_description_content_type = 'text/markdown'
 
 NAME = "dmipy"
 MAINTAINER = "Rutger Fick"
 MAINTAINER_EMAIL = "fick.rutger@gmail.com"
 DESCRIPTION = description
-LONG_DESCRIPTION = long_description
 LONG_DESCRIPTION_CONTENT_TYPE = long_description_content_type
 URL = "https://github.com/AthenaEPI/dmipy"
 DOWNLOAD_URL = ""

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,14 @@ with open(ver_file) as f:
 with open ('requirements.txt', "r") as f:
     requirements=f.read().splitlines()[::-1]
 
+with open('README.md', 'r') as f:
+    long_description = f.read()
+
 opts = dict(name=NAME,
             maintainer=MAINTAINER,
             maintainer_email=MAINTAINER_EMAIL,
             description=DESCRIPTION,
-            long_description=LONG_DESCRIPTION,
+            long_description=long_description,
             long_description_content_type=LONG_DESCRIPTION_CONTENT_TYPE,
             url=URL,
             download_url=DOWNLOAD_URL,


### PR DESCRIPTION
The ../README.md call in version.py on one side was granting the long
description to be properly defined in the setup process, but on the
other it was making `import dmipy` crash.

To solve the problem, the opening of the file is moved to setup.py

This allows to pack everything for PyPi.