### PR TITLE
force scipy version 1.4.1

### DIFF
--- a/dmipy/version.py
+++ b/dmipy/version.py
@@ -28,15 +28,12 @@ CLASSIFIERS = ["Development Status :: 3 - Alpha",
 # Description should be a one-liner:
 description = "dmipy: diffusion microstructure imaging in python"
 # Long description will go up on the pypi page
-with open('README.md', 'r') as f:
-    long_description = f.read()
 long_description_content_type = 'text/markdown'
 
 NAME = "dmipy"
 MAINTAINER = "Rutger Fick"
 MAINTAINER_EMAIL = "fick.rutger@gmail.com"
 DESCRIPTION = description
-LONG_DESCRIPTION = long_description
 LONG_DESCRIPTION_CONTENT_TYPE = long_description_content_type
 URL = "https://github.com/AthenaEPI/dmipy"
 DOWNLOAD_URL = ""

--- a/dmipy/version.py
+++ b/dmipy/version.py
@@ -4,7 +4,7 @@ from os.path import join as pjoin
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 1
 _version_minor = 0
-_version_micro = 4  # use '' for first of series, number for 1 and above
+_version_micro = 5  # use '' for first of series, number for 1 and above
 _version_extra = ''
 # _version_extra = ''  # Uncomment this for full releases
 
@@ -58,4 +58,4 @@ PACKAGE_DATA = {
         pjoin('data', 'isbi2015_white_matter_challenge', '*')
     ]
 }
-REQUIRES = ["dipy", "scipy", "numpy (>=1.13)"]
+REQUIRES = ["dipy", "scipy (==1.4.1)", "numpy (>=1.13)"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy(>=1.13)
-scipy
+scipy(==1.4.1)
 dipy
 cvxpy
 boto

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,14 @@ with open(ver_file) as f:
 with open ('requirements.txt', "r") as f:
     requirements=f.read().splitlines()[::-1]
 
+with open('README.md', 'r') as f:
+    long_description = f.read()
+
 opts = dict(name=NAME,
             maintainer=MAINTAINER,
             maintainer_email=MAINTAINER_EMAIL,
             description=DESCRIPTION,
-            long_description=LONG_DESCRIPTION,
+            long_description=long_description,
             long_description_content_type=LONG_DESCRIPTION_CONTENT_TYPE,
             url=URL,
             download_url=DOWNLOAD_URL,


### PR DESCRIPTION
Something was changed by scipy in the optimization functions after version 1.4.1.

This PR proposes to force dmipy to work with scipy 1.4.1.

The new dmipy version goes from 1.0.4 to 1.0.5.