### PR TITLE
Fix installation issues with Python >= 3.8

### DIFF
--- a/dmipy/core/acquisition_scheme.py
+++ b/dmipy/core/acquisition_scheme.py
@@ -82,9 +82,9 @@ class DmipyAcquisitionScheme:
             elif self.delta is not None and self.Delta is None:
                 deltas = np.c_[self.delta]
             else:
-                deltas = []
+                deltas = np.array([])
 
-            if deltas == []:
+            if deltas.size ==0: 
                 deltas = np.c_[np.zeros(len(self.bvalues))]
             unique_deltas = np.unique(deltas, axis=0)
             self.shell_indices = np.zeros(len(bvalues), dtype=int)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy(>=1.13)
-scipy(==1.4.1)
+scipy(>=1.4.1)
 dipy
 cvxpy
 boto


### PR DESCRIPTION
 - Unpinned schipy dependency: Updated the schipy version constraint to allow installation with newer (>=3.8) Python versions.
- Fixed numpy empty array check: Corrected the conditional check for empty arrays in the code to ensure compatibility with newer versions of NumPy (replaced == [] with .size == 0).
