### PR TITLE
docs(readme): revival banner → dmrai-lab/dmipy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+> [!IMPORTANT]
+> ### 🚀 Dmipy is revived — and has a new home
+>
+> This original **AthenaEPI/dmipy** (2019) toolbox has been **revived, subsumed, and substantially expanded** under the new **[`dmrai-lab/dmipy`](https://github.com/dmrai-lab/dmipy)** umbrella. The project is now two engines that share one acquisition-and-tissue description:
+>
+> - **[dmipy-fit](https://github.com/dmrai-lab/dmipy-fit)** — the analytical inverse: the modular multi-compartment model design and fitting you know from here, now JAX / GPU-accelerated.
+> - **[dmipy-sim](https://github.com/dmrai-lab/dmipy-sim)** — a new Monte-Carlo forward simulator: arbitrary triangular-mesh substrates, membrane permeability, surface relaxivity, and more.
+>
+> 👉 **Install the maintained stack:** `pip install dmipy` (now v2.1.0) &nbsp;·&nbsp; **Docs:** [dmipy.org](https://dmipy.org)
+>
+> The code below remains available for reference and for reproducing the original 2019 release.
+
+---
+
 [![Build Status](https://travis-ci.org/AthenaEPI/dmipy.svg?branch=master)](https://travis-ci.org/AthenaEPI/dmipy)
 [![codecov](https://codecov.io/gh/AthenaEPI/dmipy/branch/master/graph/badge.svg)](https://codecov.io/gh/AthenaEPI/dmipy)
 [![Coverage Status](https://coveralls.io/repos/github/AthenaEPI/dmipy/badge.svg)](https://coveralls.io/github/AthenaEPI/dmipy)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > - **[dmipy-fit](https://github.com/dmrai-lab/dmipy-fit)** — the analytical inverse: the modular multi-compartment model design and fitting you know from here, now JAX / GPU-accelerated.
 > - **[dmipy-sim](https://github.com/dmrai-lab/dmipy-sim)** — a new Monte-Carlo forward simulator: arbitrary triangular-mesh substrates, membrane permeability, surface relaxivity, and more.
 >
-> 👉 **Install the maintained stack:** `pip install dmipy` (now v2.1.0) &nbsp;·&nbsp; **Docs:** [dmipy.org](https://dmipy.org)
+> 👉 **Install the maintained stack:** `pip install dmipy` (now v2.1.0) &nbsp;·&nbsp; **Docs:** [dmipy.org](https://dmipy.org) &nbsp;·&nbsp; **Coming from 1.x?** [What's changed](https://dmipy.org/migrating/)
 >
 > The code below remains available for reference and for reproducing the original 2019 release.
 


### PR DESCRIPTION
Adds a banner at the top of `README.md` announcing that the original AthenaEPI/dmipy (2019) toolbox is revived and now subsumed + expanded under the new **[`dmrai-lab/dmipy`](https://github.com/dmrai-lab/dmipy)** umbrella:

- links the two engines — [dmipy-fit](https://github.com/dmrai-lab/dmipy-fit) (analytical inverse, JAX/GPU) and [dmipy-sim](https://github.com/dmrai-lab/dmipy-sim) (Monte-Carlo forward: meshes, permeability, surface relaxivity)
- points to the maintained stack (`pip install dmipy`, now v2.1.0) and [dmipy.org](https://dmipy.org)
- keeps the existing README intact below the banner for reference / 2019 reproducibility

**Scope:** `README.md` only — no code or other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)